### PR TITLE
Removed -input_pattern glob, as the ffmpeg version on the cluster doe…

### DIFF
--- a/visualize/helper_methods.py
+++ b/visualize/helper_methods.py
@@ -12,7 +12,7 @@ import IPython
 import glob
 import numpy as np
 
-def write_video_from_images(images_dir, out_path, fps = 24, match_pattern = '*.png', glob=True):
+def write_video_from_images(images_dir, out_path, fps = 24, match_pattern = r'%d.png'):
     '''
     Creates a video from a set of images. Images must be specified as a path to a directory that contains the images.
     Uses glob pattern pmatching by default (allows for using the "*" as a wildcard). Glob is not enabled by default on Windows machines.
@@ -26,7 +26,7 @@ def write_video_from_images(images_dir, out_path, fps = 24, match_pattern = '*.p
         - glob: whether to use glob type pattern matching. Possibly unsupported on Windows.
     '''
     out = os.subprocess.call([
-        "ffmpeg", "-y", "-r", str(fps), "-pattern_type glob"*glob, "-i", images_dir+"/%"+match_pattern, "-vcodec", "mpeg4", "-qscale", "5", "-r", str(fps), out_path
+        "ffmpeg", "-y", "-r", str(fps), "-i", images_dir+"/"+match_pattern, "-vcodec", "mpeg4", "-qscale", "5", "-r", str(fps), out_path
         ])
     if out != 0:
         print('Something went wrong. Make sure:')


### PR DESCRIPTION
…snt have glob

Input patter is now by default %d.png



┆Issue is synchronized with this [Trello card](https://trello.com/c/u4YxcBbx) by [Unito](https://www.unito.io)
