### PR TITLE
remove duplicate definitions of scale_apical

### DIFF
--- a/getting_started/example_data/functional_constraints/ongoing_activity/ongoing_activity.py
+++ b/getting_started/example_data/functional_constraints/ongoing_activity/ongoing_activity.py
@@ -214,27 +214,6 @@ def scan_directory(path, fnames, suffix):
         else:
             continue
 
-
-def scale_apical(cell):
-    '''
-    scale apical diameters depending on
-    distance to soma; therefore only possible
-    after creating complete cell
-    '''
-    dendScale = 2.5
-    for sec in cell.sections:
-        if sec.label == 'ApicalDendrite':
-            dist = cell.distance_to_soma(sec, 1.0)
-            if dist > 1000.0:
-                continue
-            dummy = h.pt3dclear(sec=sec)
-            for i in range(sec.nrOfPts):
-                x, y, z = sec.pts[i]
-                sec.diamList[i] = sec.diamList[i] * dendScale
-                d = sec.diamList[i]
-                dummy = h.pt3dadd(x, y, z, d, sec=sec)
-
-
 if __name__ == '__main__':
     if len(sys.argv) == 4:
         name = sys.argv[1]

--- a/simrun/syn_strength_simrun.py
+++ b/simrun/syn_strength_simrun.py
@@ -341,27 +341,6 @@ def write_sim_results(fname, t, v):
             line += '\n'
             outputFile.write(line)
 
-
-def scale_apical(cell):
-    '''
-    scale apical diameters depending on
-    distance to soma; therefore only possible
-    after creating complete cell
-    '''
-    dendScale = 2.5
-    for sec in cell.sections:
-        if sec.label == 'ApicalDendrite':
-            dist = cell.distance_to_soma(sec, 1.0)
-            if dist > 1000.0:
-                continue
-            dummy = h.pt3dclear(sec=sec)
-            for i in range(sec.nrOfPts):
-                x, y, z = sec.pts[i]
-                sec.diamList[i] = sec.diamList[i] * dendScale
-                d = sec.diamList[i]
-                dummy = h.pt3dadd(x, y, z, d, sec=sec)
-
-
 if __name__ == '__main__':
     modelName = sys.argv[1]
     nwName = sys.argv[2]

--- a/simrun/utils.py
+++ b/simrun/utils.py
@@ -103,50 +103,6 @@ def load_param_file_if_path_is_provided(pathOrParam):
         logger.warning("Returning parameter object as is (type: {})".format(type(pathOrParam)))
         return pathOrParam
 
-def scale_apical(cell):
-    '''Scale a cell's apical diameters depending on the distance to soma.
-    
-    This method scales the apical diameters of a cell with a factor of :math:`2.5` if
-    the section is within a distance of :math:`1000 \mu m` from the soma.
-    
-    :skip-doc:
-    
-    .. deprecated:: 0.1
-        This method is deprecated and will be removed in future versions.
-        Use :py:meth:`single_cell_parser.cell_modify_functions.scale_apical` instead.
-    
-    Args:
-        cell (:py:class:`single_cell_parser.cell.Cell`): The cell object.
-        
-    Return:
-        None: Updates the cell object in place.
-    '''
-    # TODO: deprecated, remove
-    import neuron
-    h = neuron.h
-    dendScale = 2.5
-    scaleCount = 0
-    for sec in cell.sections:
-        if sec.label == 'ApicalDendrite':
-            dist = cell.distance_to_soma(sec, 1.0)
-            if dist > 1000.0:
-                continue
-            # for cell 86:
-            if scaleCount > 32:
-                break
-            scaleCount += 1
-            # dummy = h.pt3dclear(sec=sec)
-            for i in range(sec.nrOfPts):
-                oldDiam = sec.diamList[i]
-                newDiam = dendScale * oldDiam
-                h.pt3dchange(i, newDiam, sec=sec)
-                # x, y, z = sec.pts[i]
-                # sec.diamList[i] = sec.diamList[i]*dendScale
-                # d = sec.diamList[i]
-                # dummy = h.pt3dadd(x, y, z, d, sec=sec)
-
-    logger.info('Scaled {:d} apical sections...'.format(scaleCount))
-
 class defaultValues:
     """
     :skip-doc:

--- a/single_cell_parser/cell_modify_functions/scale_apical_morph_86.py
+++ b/single_cell_parser/cell_modify_functions/scale_apical_morph_86.py
@@ -39,8 +39,6 @@ def scale_apical_morph_86(cell):
                 oldDiam = sec.diamList[i]
                 newDiam = dendScale * oldDiam
                 h.pt3dchange(i, newDiam, sec=sec)
-
-
                 # x, y, z = sec.pts[i]
                 # sec.diamList[i] = sec.diamList[i]*dendScale
                 # d = sec.diamList[i]

--- a/tests/test_simrun/BAC_firing_test.py
+++ b/tests/test_simrun/BAC_firing_test.py
@@ -396,38 +396,6 @@ def get_apical_section_at_distance(cell, distance):
     return closestSec
 
 
-def scale_apical(cell):
-    '''
-    scale apical diameters depending on
-    distance to soma; therefore only possible
-    after creating complete cell
-    '''
-    dendScale = 2.5
-    scaleCount = 0
-    for sec in cell.sections:
-        if sec.label == 'ApicalDendrite':
-            dist = cell.distance_to_soma(sec, 1.0)
-            if dist > 1000.0:
-                continue
-#            for cell 86:
-            if scaleCount > 32:
-                break
-            scaleCount += 1
-            #            dummy = h.pt3dclear(sec=sec)
-            for i in range(sec.nrOfPts):
-                oldDiam = sec.diamList[i]
-                newDiam = dendScale * oldDiam
-                h.pt3dchange(i, newDiam, sec=sec)
-
-
-#                x, y, z = sec.pts[i]
-#                sec.diamList[i] = sec.diamList[i]*dendScale
-#                d = sec.diamList[i]
-#                dummy = h.pt3dadd(x, y, z, d, sec=sec)
-
-    logger.info('Scaled {:d} apical sections...'.format(scaleCount))
-
-
 def write_sim_results(fname, t, v):
     with open(fname, 'w') as outputFile:
         header = '# simulation results\n'

--- a/tests/test_simrun/passive_properties_test.py
+++ b/tests/test_simrun/passive_properties_test.py
@@ -120,38 +120,6 @@ def compute_tau_effective(t, v):
     return tau
 
 
-def scale_apical(cell):
-    '''
-    scale apical diameters depending on
-    distance to soma; therefore only possible
-    after creating complete cell
-    '''
-    dendScale = 2.5
-    scaleCount = 0
-    for sec in cell.sections:
-        if sec.label == 'ApicalDendrite':
-            dist = cell.distance_to_soma(sec, 1.0)
-            if dist > 1000.0:
-                continue
-#            for cell 86:
-            if scaleCount > 32:
-                break
-            scaleCount += 1
-            #            dummy = h.pt3dclear(sec=sec)
-            for i in range(sec.nrOfPts):
-                oldDiam = sec.diamList[i]
-                newDiam = dendScale * oldDiam
-                h.pt3dchange(i, newDiam, sec=sec)
-
-
-#                x, y, z = sec.pts[i]
-#                sec.diamList[i] = sec.diamList[i]*dendScale
-#                d = sec.diamList[i]
-#                dummy = h.pt3dadd(x, y, z, d, sec=sec)
-
-    logger.info('Scaled {:d} apical sections...'.format(scaleCount))
-
-
 def write_sim_results(fname, t, v):
     with open(fname, 'w') as outputFile:
         header = '# simulation results\n'

--- a/tests/test_simrun/simrun_test.py
+++ b/tests/test_simrun/simrun_test.py
@@ -10,7 +10,7 @@ import single_cell_parser as scp
 import neuron
 from ..test_simrun import decorators
 import numpy as np
-from simrun.utils import scale_apical
+from single_cell_parser.cell_modify_functions.scale_apical_morph_86 import scale_apical_morph_86
 import simrun.generate_synapse_activations
 import simrun.run_new_simulations
 import simrun.run_existing_synapse_activations
@@ -135,7 +135,7 @@ def test_reproduce_simulation_trial_from_roberts_model_control(tmpdir, client):
             nprocs=1,
             tStop=345,
             silent=True,
-            scale_apical=scale_apical)
+            scale_apical=scale_apical_morph_86)
         dummy = client.compute(dummy).result()
 
         #synapse activation

--- a/tests/test_simrun/sustained_firing_test.py
+++ b/tests/test_simrun/sustained_firing_test.py
@@ -137,38 +137,6 @@ def soma_injection(cell,
     return t, vmSoma
 
 
-def scale_apical(cell):
-    '''
-    scale apical diameters depending on
-    distance to soma; therefore only possible
-    after creating complete cell
-    '''
-    dendScale = 2.5
-    scaleCount = 0
-    for sec in cell.sections:
-        if sec.label == 'ApicalDendrite':
-            dist = cell.distance_to_soma(sec, 1.0)
-            if dist > 1000.0:
-                continue
-#            for cell 86:
-            if scaleCount > 32:
-                break
-            scaleCount += 1
-            #            dummy = h.pt3dclear(sec=sec)
-            for i in range(sec.nrOfPts):
-                oldDiam = sec.diamList[i]
-                newDiam = dendScale * oldDiam
-                h.pt3dchange(i, newDiam, sec=sec)
-
-
-#                x, y, z = sec.pts[i]
-#                sec.diamList[i] = sec.diamList[i]*dendScale
-#                d = sec.diamList[i]
-#                dummy = h.pt3dadd(x, y, z, d, sec=sec)
-
-    logger.info('Scaled {:d} apical sections...'.format(scaleCount))
-
-
 def write_sim_results(fname, t, v):
     with open(fname, 'w') as outputFile:
         header = '# simulation results\n'


### PR DESCRIPTION
scale_apical is defined in `scp.cell_modify_functions`, and does not require duplicate definitions in other parts of the code.

Small note: in most times where I removed duplicate definitions of `scale_apical`, it really was `scale_apical_morph_86`