### PR TITLE
Add pixi tasks for dask and jupyter

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,3 +60,28 @@ ipywidgets = ">=8.1.5,<9"
 
 [tool.pixi.pypi-options]
 no-build-isolation = ["pandas-msgpack"]
+
+[tool.pixi.tasks]
+launch_dask_server = {cmd = [
+  "dask-scheduler", 
+  "--port=$port_number", 
+  "--bokeh-port=$bokeh_port", 
+  "--host=localhost"
+  ], description = "Launch a Dask scheduler", env = {port_number = "8786", bokeh_port = "8787"}}
+
+launch_dask_workers = {cmd = [
+  "dask-worker", 
+  "tcp://localhost:8786", 
+  "--nthreads=1", 
+  "--nprocs=$ISF_NUM_WORKERS", 
+  "--memory-limit=100e15", 
+  "--bokeh-port=$bokeh_port"
+  ], description = "Launch Dask workers", env = {bokeh_port = "8787", ISF_NUM_WORKERS = "4"}}
+
+launch_jupyter_server = {cmd = [
+        'jupyter-lab',
+        "--ip='*'",
+        '--no-browser',
+        '--port=$ISF_LAB_PORT',
+        "--NotebookApp.allow_origin='*'"
+    ], description = "Launching jupyter lab server", env = {ISF_LAB_PORT = "11113"}}


### PR DESCRIPTION
Added the launching of dask and jupyter servers as a pixi task. This makes it convenient to access default commands to do so.

Note that these ways of launching dask and jupyter servers may not be compatible with every usecase. It serves as a template, and as default settings.

Todo:
Pixi does not yet support background tasks (because windows is being annoying). As soon as it does, it would be convenient to make one pixi task that launches all servers in the background. As of now, each task needs to be run separately in a different shell.