### PR TITLE
remove msgpack imports for Py3

### DIFF
--- a/data_base/isf_data_base/IO/LoaderDumper/reduced_lda_model.py
+++ b/data_base/isf_data_base/IO/LoaderDumper/reduced_lda_model.py
@@ -33,14 +33,15 @@ from . import parent_classes
 import os, cloudpickle
 from simrun.reduced_model.get_kernel import ReducedLdaModel
 from data_base.data_base import DataBase, get_db_by_unique_id
-from . import pandas_to_parquet, pandas_to_msgpack
-from . import numpy_to_zarr, numpy_to_msgpack
+from . import pandas_to_parquet
+from . import numpy_to_zarr
 import pandas as pd
 import compatibility
 import six
 import json
 
 if six.PY2:
+    from . import numpy_to_msgpack
     numpy_dumper = numpy_to_msgpack
 elif six.PY3:
     numpy_dumper = numpy_to_zarr
@@ -103,6 +104,7 @@ def dump(obj, savedir):
     db_list = Rm.db_list
 
     if six.PY2:
+        from . import pandas_to_msgpack
         st_dumper = pandas_to_msgpack
     elif six.PY3:
         st_dumper = pandas_to_parquet

--- a/data_base/isf_data_base/db_initializers/synapse_activation_binning.py
+++ b/data_base/isf_data_base/db_initializers/synapse_activation_binning.py
@@ -19,7 +19,7 @@ from functools import partial
 import numpy as np
 import dask, six
 from data_base.analyze.temporal_binning import universal as temporal_binning
-from data_base.isf_data_base.IO.LoaderDumper import numpy_to_zarr, numpy_to_msgpack
+from data_base.isf_data_base.IO.LoaderDumper import numpy_to_zarr
 import logging
 logger = logging.getLogger("ISF").getChild(__name__)
 try:
@@ -28,6 +28,7 @@ except ImportError:
     logger.warning("Could not import excitatory/inhibitory celltypes from barrel_cortex. Is the module available?")
 
 if six.PY2:
+    from data_base.isf_data_base.IO.LoaderDumper import numpy_to_msgpack
     numpy_dumper = numpy_to_msgpack
 elif six.PY3:
     numpy_dumper = numpy_to_zarr


### PR DESCRIPTION
`msgpack` dumpers are now only imported in Py2, but not Py3.

Currently, the only place where `msgpack` is still imported, is when importing a `msgpack`-related dumper. This happens during the initialization of `compatibility`, which is called when importing `data_base` to account for `model_data_base` compatibility, among other things.
If I were to get `compatibility` to work without importing modules, it would in theory be possible to run an ISF py3 installation without `msgpack` alltogether. 
Something to keep in mind, but this is not on the plan.