### PR TITLE
Move specification of EXC/INH to config.

### DIFF
--- a/Interface.py
+++ b/Interface.py
@@ -281,8 +281,7 @@ def get_client(client_port=38786, timeout=120):
 print("\n\n")
 print_module_versions()
 
-import barrel_cortex
-from barrel_cortex import excitatory, inhibitory, color_cellTypeColorMap, color_cellTypeColorMap_L6paper, color_cellTypeColorMap_L6paper_with_INH
+from config import EXCITATORY, INHIBITORY
 
 import compatibility
 

--- a/barrel_cortex/__init__.py
+++ b/barrel_cortex/__init__.py
@@ -55,7 +55,7 @@ def synapse_group_function_L6paper(celltype):
     Groups celltypes in the same fashion as :cite:t:`Egger_Narayanan_Guest_Bast_Udvary_Messore_Das_de_Kock_Oberlaender_2020`
     """
     celltype = celltype.split('_')[0]
-    if celltype in inhibitory:
+    if celltype in INHIBITORY:
         return 'INH'
     else:
         return celltype
@@ -88,7 +88,7 @@ def synapse_group_function_HZpaper(celltype):
     """
     if '_' in celltype:
         celltype = celltype.split('_')[0]
-    if celltype in inhibitory or celltype == 'INH':
+    if celltype in INHIBITORY or celltype == 'INH':
         key = 'INT'
     elif celltype in ('L4ss', 'L4py', 'L4sp'):
         key = 'L4ss'
@@ -108,11 +108,11 @@ def synapse_group_function_HZpaper(celltype):
         raise ValueError(celltype)
     return key
 
-excitatory = [
+EXCITATORY = [
     'L6cc', 'L2', 'VPM', 'L4py', 'L4ss', 'L4sp', 'L5st', 'L6ct', 'L34',
     'L6ccinv', 'L5tt', 'Generic'
 ]
-inhibitory = [
+INHIBITORY = [
     'SymLocal1', 'SymLocal2', 'SymLocal3', 'SymLocal4', 'SymLocal5',
     'SymLocal6', 'L45Sym', 'L1', 'L45Peak', 'L56Trans', 'L23Trans',
     'GenericINH', 'INH'

--- a/config/cell_types.py
+++ b/config/cell_types.py
@@ -1,0 +1,30 @@
+"""Cell type configuration.
+
+This module keeps track of which cell types are used throughout ISF.
+This should be set on a per-project basis. Adapting this file usually invalidates previously created
+:ref:`syn_file_format` files, :ref:`conf_file_format` files, and :ref:`network_param_file_format` files.
+
+These cell types are used to keep track of presynaptic cells in network modeling, and their
+associated synapse types.
+"""
+
+# - Barrel cortex cell types
+EXCITATORY = [
+    "L1",       # Layer 1
+    "L2",       # Layer 2
+    "L34",      # Layer 3/4
+    "L4py",     # Layer 4 pyramidal
+    "L4sp",     # Layer 4 spiny
+    "L4ss",     # Layer 4 spiny stellate
+    "L5st",     # Layer 5 slender-tufted
+    "L5tt",     # Layer 5 thick-tufted
+    "L6cc",     # Layer 6 cortico-cortical
+    "L6ccinv",  # Layer 6 cortico-cortical inverted
+    "L6ct",     # Layer 6 corticothalamic
+    "VPM"       # Ventral posteromedial nucleus (VPM)
+    ]
+INHIBITORY = ["INH"]
+
+# - Generic cell types
+# EXCITATORY = ["EXC"]
+# INHIBITORY = ["INH"]

--- a/data_base/analyze/__init__.py
+++ b/data_base/analyze/__init__.py
@@ -8,21 +8,17 @@ See also:
 """
 
 
-import barrel_cortex
 from .spike_detection import spike_detection
 from . import spatiotemporal_binning
 import logging
 logger = logging.getLogger("ISF").getChild(__name__)
-try:
-    from barrel_cortex import excitatory, inhibitory
-except ImportError:
-    logger.warning("Could not import excitatory/inhibitory celltypes from barrel_cortex. Is the module available?")
+from config.cell_types import EXCITATORY, INHIBITORY
 
 def split_synapse_activation(
     sa,
     selfcheck=True,
-    excitatory=excitatory,
-    inhibiotry=inhibitory):
+    excitatory=EXCITATORY,
+    inhibitory=INHIBITORY):
     '''Augment a :ref:`synapse_activation_format` dataframe with a boolean column for excitatory/inhibitory.
     
     Args:
@@ -36,12 +32,6 @@ def split_synapse_activation(
     Returns:
         tuple: a :py:class:`~pandas.DataFrame` with excitatory synapse activations, and one for inhibitory synapse activations.
     '''
-    if excitatory is None:
-        import barrel_cortex
-        excitatory = barrel_cortex.excitatory
-    if inhibitory is None:
-        import barrel_cortex
-        inhibitory = barrel_cortex.inhibitory
     if selfcheck:
         celltypes = sa.apply(
             lambda x: x.synapse_type.split('_')[0], 

--- a/data_base/analyze/analyze_input_mapper_result.py
+++ b/data_base/analyze/analyze_input_mapper_result.py
@@ -10,17 +10,15 @@ import matplotlib.pyplot as plt
 import seaborn as sns
 from data_base.IO.roberts_formats import read_InputMapper_summary
 from ..utils import select
+from config.cell_types import EXCITATORY
 import logging
 logger = logging.getLogger("ISF").getChild(__name__)
-try:
-    from barrel_cortex import excitatory, inhibitory
-except ImportError:
-    logger.warning("Could not import excitatory/inhibitory celltypes from barrel_cortex. Is the module available?")
 
 
-def get_neuronet_data(COLUMN='C2',
-                      POSTSYNAPTIC_CELLTYPE='L5tt',
-                      innervation_table=None):
+def get_neuronet_data(
+        COLUMN='C2',
+        POSTSYNAPTIC_CELLTYPE='L5tt',
+        innervation_table=None):
     if innervation_table is None:
         innervation_table = pd.read_csv(
             '/nas1/Data_regger/AXON_SAGA/Axon2/NeuroNet/cache_Vincent_complete_final/data/synTotal_toC2.csv'
@@ -36,7 +34,7 @@ def get_neuronet_data(COLUMN='C2',
                               inplace=True)
     innervation_EXCINH = innervation_per_type.groupby(
         lambda x: 'EXC'
-        if x in excitatory else 'INH', axis=1).apply(lambda x: x.sum(axis=1))
+        if x in EXCITATORY else 'INH', axis=1).apply(lambda x: x.sum(axis=1))
     return {
         'all': innervation_table,
         'per_type': innervation_per_type,
@@ -52,7 +50,7 @@ def get_input_mapper_data(path_to_summmary):
         ]]
     out['per_type'] = out['per_type'].set_index('Presynaptic cell type')
     out['EXCINH'] = out['per_type'].groupby(
-        lambda x: 'EXC' if x in excitatory else 'INH').apply(sum)
+        lambda x: 'EXC' if x in EXCITATORY else 'INH').apply(sum)
     return out
 
 

--- a/data_base/isf_data_base/db_initializers/prepare_ANN_batches.py
+++ b/data_base/isf_data_base/db_initializers/prepare_ANN_batches.py
@@ -13,6 +13,7 @@ import pandas as pd
 from data_base.utils import silence_stdout, convertible_to_int, chunkIt
 from data_base.analyze.spike_detection import spike_in_interval
 from functools import partial
+from config.cell_types import EXCITATORY, INHIBITORY
 
 
 def get_binsize(length, binsize_goal=50):
@@ -342,8 +343,7 @@ def augment_synapse_activation_df_with_branch_bin(
         pd.DataFrame: The augmented dataframe with the additional columns 'section/branch_bin', 'celltype', 'EI', and 'syn_weight' (if synaptic_weight_dict is provided).
     """
     if excitatory_celltypes is None:
-        from barrel_cortex import excitatory
-        excitatory_celltypes = excitatory
+        excitatory_celltypes = EXCITATORY
     
     out = []
     for secID, df in sa_.groupby('section_ID'):
@@ -574,8 +574,7 @@ def load_syn_weights(db, client, excitatory_celltypes=None):
         :py:meth:`~data_base.isf_data_base.db_initializers.load_simrun_general.init` for the database initialization.
     """
     if excitatory_celltypes is None:
-        from barrel_cortex import excitatory
-        excitatory_celltypes = excitatory
+        excitatory_celltypes = EXCITATORY
     folder_ = db['parameterfiles_network_folder']
     fnames = db['parameterfiles_network_folder'].listdir()
     fnames.pop(fnames.index('Loader.pickle'))

--- a/data_base/isf_data_base/db_initializers/somatic_summation_model.py
+++ b/data_base/isf_data_base/db_initializers/somatic_summation_model.py
@@ -12,7 +12,7 @@ from functools import partial
 import pandas as pd
 from simrun.somatic_summation_model import ParseVT
 from ..IO.LoaderDumper import dask_to_parquet
-
+from config.cell_types import EXCITATORY, INHIBITORY
 # dask_to_parquet = data_base.IO.LoaderDumper.dask_to_parquet
 from collections import defaultdict
 import single_cell_parser as scp
@@ -174,9 +174,6 @@ def get_db_loader_dict(db, descriptor=None, PSPClass_name=None):
     return db_loader_dict
 
 
-import barrel_cortex
-
-
 class DistributedDDFWithSaveMethod:
 
     def __init__(self, db=None, key=None, ddf=None, dumper=None, scheduler=None):
@@ -213,9 +210,9 @@ def init(
     if individual_weights:
         description_key = description_key + '_individual_weights'
     if select_celltypes is not None:
-        if select_celltypes == barrel_cortex.excitatory:
+        if sorted(select_celltypes) == sorted(EXCITATORY):
             suffix = 'EXC'
-        elif select_celltypes == barrel_cortex.inhibitory:
+        elif sorted(select_celltypes) == sorted(INHIBITORY):
             suffix = 'INH'
         else:
             suffix = '_'.join(sorted(select_celltypes))

--- a/data_base/isf_data_base/db_initializers/synapse_activation_binning.py
+++ b/data_base/isf_data_base/db_initializers/synapse_activation_binning.py
@@ -20,12 +20,9 @@ import numpy as np
 import dask, six
 from data_base.analyze.temporal_binning import universal as temporal_binning
 from data_base.isf_data_base.IO.LoaderDumper import numpy_to_zarr
+from config.cell_types import EXCITATORY, INHIBITORY
 import logging
 logger = logging.getLogger("ISF").getChild(__name__)
-try:
-    from barrel_cortex import excitatory, inhibitory
-except ImportError:
-    logger.warning("Could not import excitatory/inhibitory celltypes from barrel_cortex. Is the module available?")
 
 if six.PY2:
     from data_base.isf_data_base.IO.LoaderDumper import numpy_to_msgpack
@@ -59,7 +56,7 @@ def prefun(df):
     df['celltype'] = dummy.str[0]
     df['presynaptic_column'] = dummy.str[1]
     df['proximal'] = (df.soma_distance < 500).replace(True, 'prox').replace(False, 'dist')
-    df['EI'] = df['celltype'].isin(excitatory).replace(True, 'EXC').replace(
+    df['EI'] = df['celltype'].isin(EXCITATORY).replace(True, 'EXC').replace(
         False, 'INH')
     bs = 50
     df['binned_somadist'] = df.soma_distance.div(bs).map(np.floor).astype(

--- a/data_base/model_data_base/mdb_initializers/prepare_ANN_batches.py
+++ b/data_base/model_data_base/mdb_initializers/prepare_ANN_batches.py
@@ -269,7 +269,7 @@ def augment_synapse_activation_df_with_branch_bin(sa_,
     sa_faster['section/branch_bin'] = sa_faster['section_ID'].astype(
         str) + '/' + sa_faster['branch_bin'].astype('str')
     sa_faster['celltype'] = sa_faster.synapse_type.str.split('_').str[0]
-    sa_faster['EI'] = sa_faster['celltype'].isin(I.excitatory).replace(
+    sa_faster['EI'] = sa_faster['celltype'].isin(I.EXCITATORY).replace(
         True, 'EXC').replace(False, 'INH')
     if synaptic_weight_dict:
         sa_faster['syn_weight'] = sa_faster['synapse_type'].map(syn_weights)
@@ -437,7 +437,7 @@ def load_syn_weights(m, client):
         syn_weights = {}
         netp = I.scp.build_parameters(folder_.join(fname))
         for celltype in netp.network:
-            if celltype.split('_')[0] in I.excitatory:
+            if celltype.split('_')[0] in I.EXCITATORY:
                 syn_weights[celltype] = netp.network[
                     celltype].synapses.receptors.glutamate_syn.weight[0]
             else:

--- a/data_base/model_data_base/mdb_initializers/somatic_summation_model.py
+++ b/data_base/model_data_base/mdb_initializers/somatic_summation_model.py
@@ -5,6 +5,7 @@ from simrun.somatic_summation_model import ParseVT
 from model_data_base.IO.LoaderDumper import dask_to_parquet
 from collections import defaultdict
 import single_cell_parser as scp
+from config.cell_types import EXCITATORY, INHIBITORY
 
 
 class CelltypeSpecificSynapticWeights:
@@ -118,9 +119,6 @@ def get_mdb_loader_dict(mdb, descriptor=None, PSPClass_name=None):
     return mdb_loader_dict
 
 
-import barrel_cortex
-
-
 class DistributedDDFWithSaveMethod:
 
     def __init__(self, mdb=None, key=None, ddf=None, dumper=None, scheduler=None):
@@ -155,9 +153,9 @@ def init(mdb,
     if individual_weights:
         description_key = description_key + '_individual_weights'
     if select_celltypes is not None:
-        if select_celltypes == barrel_cortex.excitatory:
+        if sorted(select_celltypes) == sorted(EXCITATORY):
             suffix = 'EXC'
-        elif select_celltypes == barrel_cortex.inhibitory:
+        elif sorted(select_celltypes) == sorted(INHIBITORY):
             suffix = 'INH'
         else:
             suffix = '_'.join(sorted(select_celltypes))

--- a/data_base/model_data_base/mdb_initializers/synapse_activation_binning.py
+++ b/data_base/model_data_base/mdb_initializers/synapse_activation_binning.py
@@ -18,11 +18,8 @@ import dask
 from data_base.analyze.temporal_binning import universal as temporal_binning
 from ..IO.LoaderDumper import numpy_to_msgpack
 import logging
+from config.cell_types import EXCITATORY
 logger = logging.getLogger("ISF").getChild(__name__)
-try:
-    from barrel_cortex import excitatory, inhibitory
-except ImportError:
-    logger.warning("Could not import excitatory/inhibitory celltypes from barrel_cortex. Is the module available?")
 
 
 def prefun(df):
@@ -31,7 +28,7 @@ def prefun(df):
     df['presynaptic_column'] = dummy.str[1]
     df['proximal'] = (df.soma_distance
                       < 500).replace(True, 'prox').replace(False, 'dist')
-    df['EI'] = df['celltype'].isin(excitatory).replace(True, 'EXC').replace(
+    df['EI'] = df['celltype'].isin(EXCITATORY).replace(True, 'EXC').replace(
         False, 'INH')
     bs = 50
     df['binned_somadist'] = df.soma_distance.div(bs).map(np.floor).astype(

--- a/simrun/reduced_model/synapse_activation.py
+++ b/simrun/reduced_model/synapse_activation.py
@@ -4,10 +4,7 @@ import single_cell_parser as scp
 import single_cell_parser.analyze as sca
 import logging
 logger = logging.getLogger("ISF").getChild(__name__)
-try:
-    from barrel_cortex import excitatory, inhibitory
-except ImportError:
-    logger.warning("Could not import excitatory/inhibitory celltypes from barrel_cortex. Is the module available?")
+from config.cell_types import EXCITATORY, INHIBITORY
 # import Interface as I # moved to bottom becose auf circular import
 
 
@@ -87,12 +84,12 @@ def get_expectancy_value_of_activated_prox_synapses_by_EI(
     EXC = sum([
         dict_[key]
         for key in list(dict_.keys())
-        if key.split('_')[0] in excitatory
+        if key.split('_')[0] in EXCITATORY
     ])
     INH = sum([
         dict_[key]
         for key in list(dict_.keys())
-        if key.split('_')[0] in inhibitory
+        if key.split('_')[0] in INHIBITORY
     ])
     return EXC, INH
 

--- a/simrun/synaptic_strength_fitting.py
+++ b/simrun/synaptic_strength_fitting.py
@@ -20,7 +20,7 @@ from collections import defaultdict
 defaultdict_defaultdict = lambda: defaultdict(lambda: defaultdict_defaultdict())
 from .utils import get_cellnumbers_from_confile, split_network_param_in_one_elem_dicts
 from .get_cell_with_network import get_cell_with_network
-from barrel_cortex import inhibitory, excitatory  # TODO: make general
+from config.cell_types import EXCITATORY, INHIBITORY
 
 logger = logging.getLogger("ISF").getChild(__name__)
 
@@ -831,7 +831,7 @@ def generate_ex_network_param_from_network_embedding(confile):
     out = defaultdict_defaultdict()
     import six
     for k, cellnumber in six.iteritems(get_cellnumbers_from_confile(confile)):
-        if not k.split('_')[0] in excitatory:
+        if not k.split('_')[0] in EXCITATORY:
             continue
         out['network'][k]['cellNr'] = cellnumber
         out['network'][k]['activeFrac'] = 1.0
@@ -878,7 +878,7 @@ def generate_inh_network_param_from_network_embedding(confile):
     import six
     out = defaultdict_defaultdict()
     for k, cellnumber in six.iteritems(get_cellnumbers_from_confile(confile)):
-        if not k.split('_')[0] in inhibitory:
+        if not k.split('_')[0] in INHIBITORY:
             continue
         out['network'][k]['cellNr'] = cellnumber
         out['network'][k]['activeFrac'] = 1.0
@@ -1120,7 +1120,7 @@ def merge_celltypes(
         defaultdict: A dictionary with concatenated voltage traces.
     """
     if celltype_must_be_in is None:
-        celltype_must_be_in = excitatory
+        celltype_must_be_in = EXCITATORY
 
     out = defaultdict_defaultdict()
     for detection_string in detection_strings:

--- a/single_cell_parser/__init__.py
+++ b/single_cell_parser/__init__.py
@@ -54,6 +54,7 @@ from sumatra.parameters import NTParameterSet
 import numpy as np
 import warnings
 from data_base.dbopen import dbopen
+from config.cell_types import EXCITATORY
 
 __author__  = "Robert Egger"
 __credits__ = ["Robert Egger", "Arco Bast"]
@@ -227,7 +228,11 @@ def init_neuron_run(simparam, vardt=False, *events):
 
 
 def sec_distance_to_soma(currentSec):
-    '''compute path length from sec(x=0) to soma'''
+    '''Compute the path length from :``sec(x=0)`` to soma
+    
+    Args:
+        currentSec (:py:class:`neuron.h.Section`): The section for which to compute the distance.
+    '''
     parentSec = currentSec.parent
     dist = 0.0
     parentLabel = parentSec.label
@@ -250,17 +255,22 @@ def spines_update_synapse_distribution_file(
         cell, 
         synapse_distribution_file,
         new_synapse_distribution_file):
-    '''Update the :ref:`syn_file_format` file to correctly point to spine heads as excitatory synapse locations. Spines must already exist, so call after create_cell, using the same :ref:`syn_file_format` file that was used to create the cell. new_synfile will be created if it does not already exist.'''
+    '''Update the :ref:`syn_file_format` file to correctly point to spine heads as excitatory synapse locations. 
+    
+    Spines must already exist, so call this after :py:meth:`create_cell`, 
+    using the same :ref:`syn_file_format` file that was used to create the cell. 
+
+    Args:
+        cell (:py:class:`~single_cell_parser.cell.Cell`): The cell object.
+        synapse_distribution_file (str): The path to the original :ref:`syn_file_format` file.
+        new_synfile (str): The path to the new :ref:`syn_file_format` file. 
+            A new_synfile will be created if it does not already exist.
+    '''
     ## update the .syn file
     spine_heads = []
     for sec in cell.sections:
         if sec.label == "SpineHead":
             spine_heads.append(sec)
-
-    excitatory = [
-        'L6cc', 'L2', 'VPM', 'L4py', 'L4ss', 'L4sp', 'L5st', 'L6ct', 'L34',
-        'L6ccinv', 'L5tt', 'Generic'
-    ]
 
     with open(synapse_distribution_file, "r") as synapse_file:
         file_data = synapse_file.readlines()
@@ -271,7 +281,7 @@ def spines_update_synapse_distribution_file(
         if n > 3:  # line 5 is first line containing data
             line_split = line.split("\t")
 
-            if (line_split[0].split("_"))[0] in excitatory:
+            if (line_split[0].split("_"))[0] in EXCITATORY:
 
                 file_data[n] = "\t".join(
                     (line_split[0], str(cell.sections.index(spine_heads[i])),
@@ -288,7 +298,14 @@ def spines_update_network_paramfile(
     network_paramfile, 
     new_network_paramfile
     ):
-    '''Update the network.param file to point to the new synapse distribution file'''
+    '''Update a :ref:`network_params_format` file to point to a new :ref:`syn_file_format` file.
+    
+    Args:
+        new_synapse_distribution_file (str): The path to the new :ref:`syn_file_format` file.
+        network_paramfile (str): The path to the original :ref:`network_params_format` file.
+        new_network_paramfile (str): The path to the new :ref:`network_params_format` file. 
+            A new_network_paramfile will be created if it does not already exist.
+    '''
     network_param = build_parameters(network_paramfile)
     for i in list(network_param.network.keys()):
         network_param.network[i].synapses.distributionFile = new_synapse_distribution_file

--- a/single_cell_parser/cell_parser.py
+++ b/single_cell_parser/cell_parser.py
@@ -1251,10 +1251,8 @@ class CellParser(object):
         logger.info(("    spine head length: {}".format(spineheadLength)))
         logger.info(("    spine head diameter: {}".format(spineheadDiam)))
 
-        excitatory = [
-            'L6cc', 'L2', 'VPM', 'L4py', 'L4ss', 'L4sp', 'L5st', 'L6ct', 'L34',
-            'L6ccinv', 'L5tt', 'Generic'
-        ]
+        from config.cell_types import EXCITATORY
+        excitatory = EXCITATORY.extend("GENERIC")
 
         def get_closest(lst, target):
             lst = np.asarray(lst)

--- a/single_cell_parser/network_param_modify_functions/__init__.py
+++ b/single_cell_parser/network_param_modify_functions/__init__.py
@@ -4,8 +4,7 @@
 
 # import Interface as I
 import pandas as pd
-import barrel_cortex
-
+from config.cell_types import EXCITATORY, INHIBITORY
 
 def change_ongoing_interval(n, factor=1, pop=None):
     '''Scales the ongoing frequency with a :paramref:`factor`.
@@ -68,7 +67,7 @@ def set_stim_onset(n, onset=None):
 def change_glutamate_syn_weights(
         param,
         g_optimal=None,
-        pop=barrel_cortex.excitatory):
+        pop=EXCITATORY):
     '''Changes the glutamate synapse weights in the :ref:`network_parameters_format` to the optimal values.
     
     Args:
@@ -85,7 +84,7 @@ def change_glutamate_syn_weights(
     '''
     for key in list(param['network'].keys()):
         celltype = key.split('_')[0]
-        if celltype in pop:  # I.excitatory:
+        if celltype in pop:
             index = [x for x in g_optimal.index if x in celltype]
             assert len(index) == 1
 
@@ -103,7 +102,7 @@ def change_glutamate_syn_weights(
                 print('g_optimal is in an unrecognised dataformat')
 
 
-def change_evoked_INH_scaling(param, factor, pop=barrel_cortex.inhibitory):
+def change_evoked_INH_scaling(param, factor, pop=INHIBITORY):
     """Scales the response probability for inhibitory cells in the :ref:`network_parameters_format`.
     
     Args:
@@ -112,8 +111,6 @@ def change_evoked_INH_scaling(param, factor, pop=barrel_cortex.inhibitory):
         pop (list): The celltypes to apply the scaling to. 
             Default is the inhibitory celltypes in the rat somatosensory cortex vS1.
 
-    See also:
-        :paramref:`barrel_cortex.inhibitory` for the inhibitory celltypes in the rat somatosensory cortex vS1.
 """
     for key in list(param.network.keys()):
         if key.split('_')[0] in pop:

--- a/singlecell_input_mapper/map_singlecell_inputs.py
+++ b/singlecell_input_mapper/map_singlecell_inputs.py
@@ -1,9 +1,16 @@
 """Map synapses onto a postsynaptic cell.
 
-This module provides a full pipeline for creating anatomical realizations of the connectivity 
-of individual neuron morphologies, based on methods and data presented in 
+This module provides a full pipeline for creating dense connectome models
+of the rat barrel cortex, based on methods and data presented in 
 :cite:t:`Udvary_Harth_Macke_Hege_De_Kock_Sakmann_Oberlaender_2022`.
-An anatomical realization refers to a set of synapses sampled from a probability distribution.
+
+This runfile assumes you have downloaded and extracted the barrel cortex model data from
+https://dataverse.harvard.edu/dataset.xhtml?persistentId=doi:10.7910/DVN/JZPULNa.
+If this is not the case, please consult ``installer/download_bc_model` and extract.
+
+Attention:
+    This file is specific to the barrel cortex model data. If you want to use it for other data,
+    you need to adapt the paths to the data accordingly.
 
 Inputs:
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -88,11 +88,23 @@ def is_port_in_use(port):
 
 
 def pytest_ignore_collect(path, config):
+    """If this evaluates to True, the test is ignored.
+    
+    Args:
+        path (str): path to the test file
+        config (Config): pytest config object
+    """
     if six.PY2:
         return (
-            path.fnmatch("/*test_data_base/data_base/*")  # only run new DataBase tests on Py2
+            path.fnmatch("/*test_data_base/data_base/*")  # only run new DataBase tests on Py3
             or path.fnmatch("/*cell_morphology_visualizer_test*")  # don't run cmv tests on Py2
             )
+    if path.fnmatch("/*test_barrel_cortex/*"):
+        bc_downloaded = os.path.exists(
+            os.path.join(
+                os.path.dirname(CURRENT_DIR),
+                "barrel_cortex"))
+        return not bc_downloaded  # skip if it is not downloaded
 
 
 def pytest_configure(config):

--- a/tests/test_simrun/synaptic_strength_fitting_test.py
+++ b/tests/test_simrun/synaptic_strength_fitting_test.py
@@ -1,8 +1,12 @@
 import Interface as I
 from . import decorators
 from . import context
-import getting_started
-import simrun.synaptic_strength_fitting
+import simrun.synaptic_strength_fitting, pytest
+try:
+    from barrel_cortex import get_EPSP_measurement
+    BC_MODEL_AVAILABLE = True
+except ImportError:
+    BC_MODEL_AVAILABLE = False
 
 PSPs = simrun.synaptic_strength_fitting.PSPs
 
@@ -19,11 +23,15 @@ PSPs = simrun.synaptic_strength_fitting.PSPs
 
 
 #@decorators.testlevel(2)
+@pytest.mark.skipif(not BC_MODEL_AVAILABLE, reason="Barrel cortex model not available, but synaptic strength values are BC-specific")
 def test_VPM_synaptic_strength_is_between_1_72_and_1_85(client):
     """
     Limits are educated guesses, but it should never deviate by a lot.
     There is some statistical fluctuation in this test due to the stochastic nature of synapse activation.
     The chosen limits of 1.72 - 1.85 should cover all possible stochastic variation by a good amount.
+
+    Attention:
+        This test is specific to the barrel cortex and assumes that the barrel cortex model is downloaded
     """
     PSPs = simrun.synaptic_strength_fitting.PSPs
     confile = I.os.path.join(
@@ -43,6 +51,6 @@ def test_VPM_synaptic_strength_is_between_1_72_and_1_85(client):
     psps._delayeds = [psps._delayeds[index] for index in indexes]
     psps._keys = [psps._keys[index] for index in indexes]
     psps.run(client)
-    optimal_g_pdf = psps.get_optimal_g(I.barrel_cortex.get_EPSP_measurement())
+    optimal_g_pdf = psps.get_optimal_g(get_EPSP_measurement())
     gVPM = optimal_g_pdf.loc['VPM_C2']['optimal g']
     assert 1.85 >= gVPM >= 1.72

--- a/visualize/cell_morphology_visualizer.py
+++ b/visualize/cell_morphology_visualizer.py
@@ -17,7 +17,7 @@ from mpl_toolkits.mplot3d.art3d import Line3DCollection
 import numpy as np
 import shutil
 from visualize.vtk import write_vtk_skeleton_file
-import os, dask, time, six, socket, barrel_cortex, warnings
+import os, dask, time, six, socket, warnings
 from .utils import write_video_from_images, write_gif_from_images, display_animation_from_images, draw_arrow
 if six.PY3:
     from scipy.spatial.transform import Rotation
@@ -757,8 +757,8 @@ class CellMorphologyVisualizer(CMVDataParser):
         self.synapse_legend = True
         self.legend = True
         self.highlight_arrow_kwargs = None        
-        self.synapse_group_function = lambda x: x # barrel_cortex.synapse_group_function_HZpaper
-        self.population_to_color_dict = {}  # barrel_cortex.color_cellTypeColorMapHotZone    
+        self.synapse_group_function = lambda x: x
+        self.population_to_color_dict = {} 
 
     def _write_png_timeseries(
         self, 


### PR DESCRIPTION
ISF now imports cell types from `config` instead of `barrel_cortex`. This allows for a central definition of which celltypes are EXC or INH, and ISF code. Default values are set to those of the barrel cortex.

Imports or mentions of the barrel cortex are removed everywhere in ISF, except for:
- testing barrel cortex related functionality. These tests are now skipped if the BC model is not downloaded
- `singlecell_input_mapper.map_singlecell_inputs`, which by design starts from empirical data, which is inherently barrel cortex specific for our case. It is documented to be a template runfile. People who want the same kind of network modeling should acquire the same kind of data, and adapt paths to the data accordingly.

This solves #274 