### PR TITLE
lazy evaluate the configuration for file locking

### DIFF
--- a/data_base/distributed_lock.py
+++ b/data_base/distributed_lock.py
@@ -42,78 +42,128 @@ Example::
 
 """
 
-import distributed
 # import fasteners
 # import redis
 import yaml
 import os
-import warnings
 from compatibility import YamlLoader
 from config.isf_logging import logger as isf_logger
+
 logger = isf_logger.getChild(__name__)
 
+# Lazy initialization of the locking server and client
+# These globals are set only when they're needed.
+_SERVER = None
+_CLIENT = None
+_CONFIG = None
 DEFAULT_CONFIG = [
-    dict(type="redis",
-            config=dict(host="spock", port=8885, socket_timeout=1)),
-    dict(type="redis",
-            config=dict(host="localhost", port=6379, socket_timeout=1)),
-    dict(type="file"),]
+    dict(type="redis", config=dict(host="spock", port=8885, socket_timeout=1)),
+    dict(type="redis", config=dict(host="localhost", port=6379, socket_timeout=1)),
+    dict(type="file"),
+]
 
-if 'ISF_DISTRIBUTED_LOCK_BLOCK' in os.environ:
-    pass
-elif 'ISF_DISTRIBUTED_LOCK_CONFIG' in os.environ:
-    config_path = os.environ['ISF_DISTRIBUTED_LOCK_CONFIG']
-    with open(os.environ['ISF_DISTRIBUTED_LOCK_CONFIG'], 'r') as f:
-        CONFIG = yaml.load(f, Loader=YamlLoader)
-else:
-    logger.attention(
-        "Environment variable ISF_DISTRIBUTED_LOCK_CONFIG is not set. " +
-        "Falling back to default configuration.")
-    CONFIG = DEFAULT_CONFIG
+def _get_locking_config():
+    """Get the locking configuration from the environment variable ``ISF_DISTRIBUTED_LOCK_CONFIG``.
+    
+    This method allows for a lazy evaluation of the locking configuration, 
+    and is used to set the global variable ``_CONFIG``.
+    """
+    global _CONFIG
 
-def get_locking_server_client():
-    """Get the file locking client object, depending on the file locking configuration.
+    # locking config is already set: return it
+    if _CONFIG is not None:
+        config = _CONFIG
     
-    File locking configuration should be set by the environment variable ``ISF_DISTRIBUTED_LOCK_CONFIG``, pointing to a path to 
-    a ``.yml`` file providing file locking configuration.
+    # check if locking is blocked
+    elif "ISF_DISTRIBUTED_LOCK_BLOCK" in os.environ:
+        config = None
     
-    See also:
-        :py:mod:`data_base.distributed_lock` for more info on the file locking configuration.
-    """ 
-    if 'ISF_DISTRIBUTED_LOCK_BLOCK' in os.environ:
-        return None, None
-    for server in CONFIG:
-        logger.info("trying to connect to distributed locking server {}".format(
-            str(server)))
+    # check if locking config is set in the env variables
+    elif "ISF_DISTRIBUTED_LOCK_CONFIG" in os.environ:
+        config_path = os.environ["ISF_DISTRIBUTED_LOCK_CONFIG"]
+        with open(config_path, "r") as f:
+            config = yaml.load(f, Loader=YamlLoader)
+
+    # use default config
+    else:
+        logger.attention(
+            "Environment variable ISF_DISTRIBUTED_LOCK_CONFIG is not set. "
+            + "Falling back to default configuration."
+        )
+        config = DEFAULT_CONFIG
+    _CONFIG = config
+    return config
+
+
+def _get_locking_server_client_from_config():
+    locking_config = _get_locking_config()
+    for server in locking_config:
+        logger.info(
+            "Trying to connect to distributed locking server {}".format(str(server))
+        )
         if server["type"] == "redis":
             import redis
             try:
                 c = redis.StrictRedis(**server["config"])
                 c.client_list()
-                print("success!")
-                return server, c
-            except (redis.exceptions.TimeoutError,
-                    redis.exceptions.ConnectionError):
-                pass
+                logger.info("success!")
+                client = c
+            except (redis.exceptions.TimeoutError, redis.exceptions.ConnectionError) as e:
+                logger.error(e)
         elif server["type"] == "file":
             logger.warning(
                 "Using file based locking. "
                 "Please be careful on nfs mounts as file based locking has issues in this case."
             )
-            return server, None
+            client = None
         elif server["type"] == "zookeeper":
             import kazoo.client
-
-            zk = kazoo.client.KazooClient(**server["config"])
-            zk.start()
-            logger.info("success!")
-            return server, zk
+            try:
+                zk = kazoo.client.KazooClient(**server["config"])
+                zk.start()
+                logger.info("success!")
+                client = zk
+            except Exception as e:
+                logger.error(e)
         else:
             raise NotImplementedError()
-    raise RuntimeError("could not connect to a locking server.")
+    return server, client
 
 
-SERVER, CLIENT = get_locking_server_client()
+def get_locking_server_client():
+    """Get the file locking client object, depending on the file locking configuration.
+
+    File locking configuration should be set by the environment variable ``ISF_DISTRIBUTED_LOCK_CONFIG``, pointing to a path to
+    a ``.yml`` file providing file locking configuration.
+
+    See also:
+        :py:mod:`data_base.distributed_lock` for more info on the file locking configuration.
+    """
+    global _SERVER
+    global _CLIENT
+
+    if "ISF_DISTRIBUTED_LOCK_BLOCK" in os.environ:
+        return None, None
+    
+    if _SERVER is None:
+        _SERVER, _CLIENT = _get_locking_server_client_from_config()
+    
+    return _SERVER, _CLIENT
+    
+
+def get_locking_client():
+    """Get the locking client"""
+    global _CLIENT
+    if _CLIENT is None:
+        _SERVER, _CLIENT = get_locking_server_client()
+    return _CLIENT
+
+def get_locking_server():
+    """Get the locking server"""
+    global _SERVER
+    if _SERVER is None:
+        _SERVER, _CLIENT = get_locking_server_client()
+    return _SERVER
 
 
 def update_config(c):
@@ -126,76 +176,84 @@ def update_config(c):
     Returns:
         None
     """
-    global SERVER
-    global CLIENT
-    global CONFIG
-    CONFIG = c
-    SERVER, CLIENT = get_locking_server_client()
+    global _CONFIG
+    global _SERVER
+    global _CLIENT
+    _CONFIG = c
+    _SERVER, _CLIENT = _get_locking_server_client_from_config()
+
 
 class InterProcessLockNoWritePermission:
-    '''Check if the target file or directory has write access, and only lock it if so.
-    
+    """Check if the target file or directory has write access, and only lock it if so.
+
     If the user has write permissions to the path, then locking is necessary. Otherwise not, and lock acquire returns True without a lock
-    
+
     Args:
         path (str): path to check.
-        
+
     See also:
         [Fasteners InterProcessLock](https://fasteners.readthedocs.io/en/latest/guide/inter_process/)
-    
+
     Attributes:
         lock (:py:class:`~fasteners.InterProcessLock` or None): The lock object if the user has write permissions, None otherwise.
-    '''
+    """
+
     def __init__(self, path):
         """
-        
+
         Args:
             path (str): path to check."""
         if os.access(path, os.W_OK):
             import fasteners
+
             self.lock = fasteners.InterProcessLock(path)
         else:
             self.lock = None
-            
+
     def acquire(self):
         """Acquire the lock on a path if the user has write permissions.
-        
+
         If the user has no write permissions, then no lock is set and ``True`` is returned.
-        
+
         Returns:
             bool: True if the lock was acquired successfully or if locking is not necessary, False otherwise.
         """
         if self.lock:
             return self.lock.acquire()
         return True
-    
+
     def release(self):
         """Release the lock on a path if it was acquired.
-        
+
         Returns:
             None
         """
         if self.lock:
             self.lock.release()
-            
+
+
 def get_lock(name):
     """Fetch the correct lock, depending on global locking server configuration.
-    
+
     Reads the locking configuration from the global variable ``SERVER`` and infers the correct lock type.
     The following locks are supported:
-    
+
     - :py:class:`~data_base.distributed_lock.InterProcessLockNoWritePermission`: for file based locking.
     - :py:class:`redis.lock.Lock`: for redis based locking.
     - :py:class:`kazoo.client.Lock`: for Apache zookeeper based locking.
-    
+
     See also:
         `Kazoo documentation <https://kazoo.readthedocs.io/en/latest/index.html>`_ and
         `Redis documentation <https://redis-py.readthedocs.io/en/stable/>`_
     """
-    if 'ISF_DISTRIBUTED_LOCK_BLOCK' in os.environ:
-        raise RuntimeError('ISF_DISTRIBUTED_LOCK_BLOCK is defined, which turns off locking.')
+    if "ISF_DISTRIBUTED_LOCK_BLOCK" in os.environ:
+        raise RuntimeError(
+            "ISF_DISTRIBUTED_LOCK_BLOCK is defined, which turns off locking."
+        )
     
-    if SERVER['type'] == 'file':
+    SERVER, CLIENT = get_locking_server_client()
+    
+    if SERVER["type"] == "file":
         return InterProcessLockNoWritePermission(name)
     elif SERVER["type"] == "redis":
         import redis
@@ -204,23 +262,27 @@ def get_lock(name):
         return CLIENT.Lock(name)
     else:
         raise RuntimeError(
-            "supported server types are redis, zookeeper and file. " +
-            "Current locking config is: {}".format(str(SERVER)))
+            "supported server types are redis, zookeeper and file. "
+            + "Current locking config is: {}".format(str(SERVER))
+        )
 
 
 def get_read_lock(name):
     """Fetch the correct read lock, depending on global locking server configuration.
-    
+
     Args:
         name (str): The name of the lock.
-        
+
     Returns:
-        :py:class:`~data_base.distributed_lock.InterProcessLockNoWritePermission` | :py:class:`redis.lock` | :py:class:`kazoo.client.Lock`: 
+        :py:class:`~data_base.distributed_lock.InterProcessLockNoWritePermission` | :py:class:`redis.lock` | :py:class:`kazoo.client.Lock`:
             The lock object.
     """
-    if 'ISF_DISTRIBUTED_LOCK_BLOCK' in os.environ:
-        raise RuntimeError('ISF_DISTRIBUTED_LOCK_BLOCK is defined, which turns off locking.')    
-    if SERVER['type'] == 'file':
+    if "ISF_DISTRIBUTED_LOCK_BLOCK" in os.environ:
+        raise RuntimeError(
+            "ISF_DISTRIBUTED_LOCK_BLOCK is defined, which turns off locking."
+        )
+    SERVER, CLIENT = get_locking_server_client()
+    if SERVER["type"] == "file":
         return InterProcessLockNoWritePermission(name)
     elif SERVER["type"] == "redis":
         import redis
@@ -229,25 +291,29 @@ def get_read_lock(name):
         return CLIENT.ReadLock(name)
     else:
         raise RuntimeError(
-            "supported server types are redis, zookeeper and file. " +
-            "Current locking config is: {}".format(str(SERVER)))
+            "supported server types are redis, zookeeper and file. "
+            + "Current locking config is: {}".format(str(SERVER))
+        )
 
 
 def get_write_lock(name):
     """Fetch the correct write lock, depending on global locking server configuration.
-    
+
     Args:
         name (str): The name of the lock.
-        
+
     Returns:
         :py:class:`~data_base.distributed_lock.InterProcessLockNoWritePermission` | :py:class:`redis.lock` | :py:class:`kazoo.client.WriteLock`:
             The lock object.
     """
-    if 'ISF_DISTRIBUTED_LOCK_BLOCK' in os.environ:
-        raise RuntimeError('ISF_DISTRIBUTED_LOCK_BLOCK is defined, which turns off locking.')    
-    if SERVER['type'] == 'file':
+    if "ISF_DISTRIBUTED_LOCK_BLOCK" in os.environ:
+        raise RuntimeError(
+            "ISF_DISTRIBUTED_LOCK_BLOCK is defined, which turns off locking."
+        )
+    SERVER, CLIENT = get_locking_server_client()
+    if SERVER["type"] == "file":
         return InterProcessLockNoWritePermission(name)
-    
+
     elif SERVER["type"] == "redis":
         import redis
         return redis.lock.Lock(CLIENT, name, timeout=300)
@@ -255,5 +321,6 @@ def get_write_lock(name):
         return CLIENT.WriteLock(name)
     else:
         raise RuntimeError(
-            "supported server types are redis, zookeeper and file. " +
-            "Current locking config is: {}".format(str(SERVER)))
+            "supported server types are redis, zookeeper and file. "
+            + "Current locking config is: {}".format(str(SERVER))
+        )


### PR DESCRIPTION
This only sets/checks the file locking config when it is needed. Otherwise, it is left at None. This is done to avoid muddying the output with file locking info when file locking is not yet needed.