### PR TITLE
Develop

### DIFF
--- a/.github/workflows/test-isf-py38-pixi-windows.yml
+++ b/.github/workflows/test-isf-py38-pixi-windows.yml
@@ -17,11 +17,23 @@ on:
 jobs:
   test:
     name: Test pixi windows
-    runs-on: ['self-hosted', 'Windows']
+    runs-on: 'windows-latest'
 
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+
+      - name: Download NEURON installer
+        shell: cmd
+        run: |
+          echo ------------ Downloading NEURON installer -------------
+          curl https://neuron.yale.edu/ftp/neuron/versions/v8.0/nrn-8.0.w64-mingwsetup.exe -o nrn_installer_8.0.exe
+
+      - name: Install NEURON
+        shell: cmd
+        run: |
+          echo ------------ Installing NEURON -------------
+          start /b /wait .\nrn_installer_8.0.exe /S /D=C:\nrn
 
       - name: Install & setup environment
         uses: prefix-dev/setup-pixi@v0.8.8
@@ -64,7 +76,7 @@ jobs:
           echo MPLBACKEND: %MPLBACKEND%
 
           echo ------------ Running tests -------------
-          pixi r pytest -n 4 --dist worksteal -rsx -vv  --color=yes --durations=0 --cov-report xml:tests\logs\report_py38.xml --cov=. tests
+          pixi r pytest -n 3 --dist worksteal -rsx -vv  --color=yes --durations=0 --cov-report xml:tests\logs\report_py38.xml --cov=. tests
 
       - name: Save test logs
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
Add windows CI on github runners.
Windows has reduced amount of pytest workers to avoid deadlocking.
In addition, there is a 10 minute timeout for the test suite to prevent deadlocking eating away precious minutes.