### PR TITLE
[DOCS] Update installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,15 +32,7 @@ Installation instructions can be found [here](https://mpinb.github.io/in_silico_
 
 ISF is available for Linux, Windows and macOS.
 For installation and environment management, ISF uses [pixi](https://pixi.sh/latest/). 
-You can install pixi on Linux and macOS by running:
-
-```bash
-curl -fsSL https://pixi.sh/latest | sh
-```
-and on Windows:
-```pwsh
-powershell -ExecutionPolicy ByPass -c "irm -useb https://pixi.sh/install.ps1 | iex"
-```
+Please follow the installation instructions on the [`pixi` documentation](https://pixi.sh/latest/#installation)
 
 To install ISF with pixi, simply:
 

--- a/README.md
+++ b/README.md
@@ -45,8 +45,7 @@ powershell -ExecutionPolicy ByPass -c "irm -useb https://pixi.sh/install.ps1 | i
 To install ISF with pixi, simply:
 
 ```bash
-git clone https://github.com/mpinb/in_silico_framework.git --depth 1 &&
-cd in_silico_framework &&
-pixi install &&
-pixi configure
+git clone https://github.com/mpinb/in_silico_framework.git --depth 1
+cd in_silico_framework
+pixi run install
 ```

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -14,7 +14,7 @@ To install ISF with ``pixi``, simply:
 
    git clone https://github.com/mpinb/in_silico_framework.git --depth 1
    cd in_silico_framework
-   pixi run setup
+   pixi run install
 
 
 .. important::

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -12,8 +12,8 @@ To install ISF with ``pixi``, simply:
 
 .. code-block:: bash
 
-   git clone https://github.com/mpinb/in_silico_framework.git --depth 1 &&
-   cd in_silico_framework &&
+   git clone https://github.com/mpinb/in_silico_framework.git --depth 1
+   cd in_silico_framework
    pixi run setup
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -149,8 +149,12 @@ cmd = [
   "--overwrite-param-files={{ overwrite_param_files }}",
 ]
 
-[tool.pixi.tasks.setup]
+[tool.pixi.tasks.install]
 depends-on = ["configure"]
+cmd = [
+  "echo",
+  "\nSuccessfully installed ISF.\n\n",
+]
 
 [tool.pixi.tasks.launch_dask_server]
 args = [


### PR DESCRIPTION
Installation instructions had unix-specific operators, which failed on windows.
Additionally changed `pixi r setup` to `pixi r install` for clarity