### PR TITLE
Improve test suite

### DIFF
--- a/CONTRIBUTE.md
+++ b/CONTRIBUTE.md
@@ -41,19 +41,20 @@ That being said, we are also welcome new ideas, and are very excited to hear how
 ### Setting up the development environment
 
 ISF uses [`pixi`](https://pixi.sh/latest) for managing environments. The default environment includes the`run dependencies`: everything you need to run ISF.
-These are often sufficient to implement new ideas. However, if you require additional dependenices, you can simply `pixi add xyz`. Before adding new dependencies to ISF, please consider the following:
+These are often sufficient to implement new ideas. However, if you require additional dependenices, you can simply `pixi add xyz`. 
+Before adding new dependencies to ISF, please consider the following:
 
-> ISF is only useful if it is stable. ISF is only stable if the dependencies, API and reproducibility do not significantly change.
-
-- Dependencies are not always maintained forever. `pandas-msgpack` and `sumatra` have been two examples of packages we had to deprecate, patch, or pin down other dependencies for.
+- Dependencies are not always maintained forever. In the past, we have had to undeprecate `pandas-msgpack` ourselves, and drop `sumatra`. Ideally, we should not take on the maintenance burden of a dependency that is not actively maintained.
 - Maintenance costs tend to scale exponentially with additional dependencies
 - Can your dependency be reasonably omitted in favor of the standard library, or other core packages such as `numpy` or `scipy`?
+
+> ISF is only useful if it is stable. ISF is only stable if the dependencies, API and reproducibility do not significantly change. Be mindful when adding dependencies
 
 ### Coding Standards and Guidelines
 
 Please follow these coding standards and guidelines:
 
-- **Code Style**: Follow PEP 8 for Python code.
+- **Code Style**: Preferably follow PEP 8 for Python code style. Autoformatting tools like `black` can help.
 - **Naming Conventions**: Use descriptive names for variables, functions, and classes.
 - **Documentation**: Write docstrings for *all* public functions, classes, and methods.
 - **Comments**: Use comments to explain complex logic and important decisions.
@@ -94,16 +95,16 @@ Write clear and descriptive commit messages. Follow these guidelines:
 
 To submit a pull request:
 
-1. **Fork the repository** and create your branch from your version of `develop`.
-2. **Commit your changes** with clear commit messages.
-3. **Push your branch** to your forked repository.
-4. **Open a pull request** against ISF's `develop` branch.
-
-In your pull request description, include:
-
-- A summary of the changes.
-- Any related issues or pull requests.
-- Steps to test the changes.
+1. **Fork the repository** 
+2. **Create a branch** for your contribution from your version of `develop`.
+3. **Commit your changes** with clear commit messages. Do not commit to `master` or `develop` directly.
+   - If your changes are related to a specific issue, include the issue number in the commit message (e.g., `Fixes #123`).
+   - Use `git commit --amend` to update the last commit message if needed.
+4. **Push your branch** to your forked repository.
+5. **Open a pull request** against the `develop` branch of the main repository.
+   - Ensure your pull request is based on the latest `develop` branch.
+   - Provide a clear title and description for your pull request.
+   - If your changes are related to an issue, link to the issue in the pull request description.
 
 ## Issue Tracking
 
@@ -130,9 +131,9 @@ We use the Google-style documentation format. The Google documentation guideline
 - Attribute blocks, argument blocks and other blocks are indented. Note that indentation also impacts rst (see example below)
 - Arguments and attributes are listed with their type in brackets: `attr_arg (type): descr`
 
-In addition to these guidelines, ISF imposes one additional rule for docstrings:
+In addition to these guidelines, ISF adds one additional rule for docstrings:
 
-- Class docstrings always end with a list of their attributes. This is in contrast to the [PEP-257 convention](https://peps.python.org/pep-0257/) where attribute docstrings come after each attribute. We use Jinja templating to parse out the attributes from the Attribute block rather than the PEP-257 convention, because the PEP-257 convention is just honestly quite a bit of work. That being said, you are of course also allowed to use the PEP-257 convention. Just don't mix the two.
+- Class docstrings that end with a list of their attributes are equivalent to the [PEP-257 convention](https://peps.python.org/pep-0257/). In PEP-257, each class attribute definition is followed by a one-line docstring. Howver, ISF uses Jinja templating to parse out attribute documentation from an `Attribute` block in the class definition, rather than the PEP-257 convention. You are of course allowed to follow PEP-257 convention. Just don't mix the two within a single class.
 
 Classes tend to be the most documentation work, so we've opted to give you an example class to showcase what you can do with documentation. `rst` directives in the docstring are allowed. most HTML themes also support example blocks, attention blocks, "see also" blocks etc.
 
@@ -164,6 +165,8 @@ class DocumentMePlease():
       esc (bool): Another test attribute
       attribute_not_arg (int): An attribute that is not in the init docstring.
   """
+  # The above "Attributes" block will be parsed by Jinja, and the attributes will be documented in the class documentation.
+  # This should not be mixed with PEP-257 (see below). Choose one convention.
   def __init__(self, test_arg, escape_me_):
     """
     Args:
@@ -173,6 +176,7 @@ class DocumentMePlease():
     self.test_attribute = test
     self.esc = escape_me_
     """esc (bool): This is a PEP-257 docstring example. Because I'm now mixing conventions, this will appear twice"""
+    # The above should not be mixed with the "Attributes" block in the class docstring.
     self.attribute_not_arg = self.test_attribute + self.esc
 ```
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -26,6 +26,18 @@ To install ISF with ``pixi``, simply:
    In case you encounter any issues, feel free to `open an issue <https://github.com/mpinb/in_silico_framework/issues>`_ and include relevant logs.
    Note that many of the core ISF workflows (network mapping, neuron model generation etc.) require extensive resources, which often implies a (Linux-based) High Performance Computing environment.
 
+.. important::
+   :title: Developer installation
+   :collapsible:
+
+   If you are planning to contribute to ISF and you have read the `contributor guidelines https://github.com/mpinb/in_silico_framework/blob/master/CONTRIBUTE.md`_, 
+   you should also clone the `develop` branch of the repository:
+
+   .. code-block:: bash
+
+      git remote set-branches origin 'develop'
+      git fetch --depth 1 origin develop
+
 
 Configuration
 -------------

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -30,7 +30,7 @@ To install ISF with ``pixi``, simply:
    :title: Developer installation
    :collapsible:
 
-   If you are planning to contribute to ISF and you have read the `contributor guidelines https://github.com/mpinb/in_silico_framework/blob/master/CONTRIBUTE.md`_, 
+   If you are planning to contribute to ISF and you have read the `contributor guidelines <https://github.com/mpinb/in_silico_framework/blob/master/CONTRIBUTE.md>`_, 
    you should also clone the `develop` branch of the repository:
 
    .. code-block:: bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -209,7 +209,6 @@ cmd = [
   "mkdir", "-p", "tests/logs", "&&",
   "pytest", 
   "-rsx",   # print skipped and expected failures
-  "-x",     # prinearly exit on first failed test
   "-n",
   "{{ n_pytest_workers }}",
   "-vv",

--- a/single_cell_parser/network.py
+++ b/single_cell_parser/network.py
@@ -608,16 +608,23 @@ class NetworkMapper:
         start = 0.0
         stop = -1.0
         nSpikes = None
-        try:
+
+        # Set params from networkParameters, if available
+        try: 
             noise = networkParameters.noise
+        except AttributeError:
+            logger.debug('\"noise\" is unset for \"spiketrain\" of cell type {:s}.'.format(preCellType))
+            logger.debug('Defaulting to noise = 1.0.')
+        try: 
             start = networkParameters.start
         except AttributeError:
-            logger.error('Could not find attributes \"noise\" or \"start\" for \"spiketrain\" of cell type {:s}.'.format(preCellType))
-            logger.error('         Support of \"spiketrains\" without these attributes is deprecated.')
-        try:
+            logger.debug('\"start\" is unset for \"spiketrain\" of cell type {:s}.'.format(preCellType))
+            logger.debug('Defaulting to start = 0.0.')
+        try: 
             nSpikes = networkParameters.nspikes
         except AttributeError:
             pass
+
         if self.simParam is not None:
             stop = self.simParam.tStop
         logger.info('initializing spike trains with mean rate {:.2f} Hz for cell type {:s}'.format(1000.0 / interval, preCellType))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,7 @@
 # this code will be run on each pytest worker before any other pytest code
 # useful to setup whatever needs to be done before the actual testing or test discovery
 # for setting environment variables, use pytest.ini or .env instead
-import logging, os, pytest
+import logging, os, pytest, sys
 from config.isf_logging import logger  # import from config to set handlers properly
 
 # --- Import fixtures
@@ -118,6 +118,20 @@ def pytest_configure(config):
     """
     pytest configuration
     """
+    # Set shorter temp directory on Windows to avoid long path issues
+    if sys.platform.startswith('win'):
+        # Create base temp directory if it doesn't exist
+        # This overrides the default temp directory for pytest
+        # to a shorter path to avoid long path issues on Windows
+        win_basetemp = "C:\\tmp\\pytest"
+        worker_id = os.environ.get("PYTEST_XDIST_WORKER", None)
+        if worker_id:
+            win_basetemp = os.path.join(win_basetemp, worker_id)
+        if not os.path.exists(win_basetemp):
+            os.makedirs(win_basetemp, exist_ok=True)
+        # Override pytest's basetemp option
+        config.option.basetemp = win_basetemp
+    
     _setup_pytest_logging()
     import mechanisms.l5pt
     mechanisms.l5pt.load()   

--- a/tests/test_simrun/simrun_test.py
+++ b/tests/test_simrun/simrun_test.py
@@ -20,12 +20,12 @@ T_STOP_SHORT = 20
 T_STOP_FULL = 345
 
 
-def test_generate_synapse_activation_returns_filelist(tmpdir, client):
+def test_generate_synapse_activation_returns_filelist(tmp_path, client):
     try:
         dummy = simrun.generate_synapse_activations.generate_synapse_activations(
             NEUP_FN,
             NETP_FN,
-            dirPrefix=tmpdir.dirname,
+            dirPrefix=str(tmp_path),
             nSweeps=1,
             nprocs=1,
             tStop=T_STOP_SHORT,
@@ -37,12 +37,13 @@ def test_generate_synapse_activation_returns_filelist(tmpdir, client):
 
 
 def test_run_existing_synapse_activation_returns_identifier_dataframe_and_results_folder(
-        tmpdir, client):
+        tmp_path, client):
     try:
         dummy = simrun.run_existing_synapse_activations.run_existing_synapse_activations(
             NEUP_FN,
-            NETP_FN, [SYN_ACT_SUBSAMPLED_FN],
-            dirPrefix=tmpdir.dirname,
+            NETP_FN, 
+            synapseActivation=[SYN_ACT_SUBSAMPLED_FN],
+            dirPrefix=str(tmp_path),
             nprocs=1,
             tStop=T_STOP_SHORT,
             silent=True)
@@ -53,12 +54,12 @@ def test_run_existing_synapse_activation_returns_identifier_dataframe_and_result
     assert isinstance(dummy[0][0][1], str)
 
 
-def test_run_new_simulations_returns_dirname(tmpdir):
+def test_run_new_simulations_returns_dirname(tmp_path):
     try:
         dummy = simrun.run_new_simulations.run_new_simulations(
             NEUP_FN,
             NETP_FN,
-            dirPrefix=tmpdir.dirname,
+            dirPrefix=str(tmp_path),
             nSweeps=1,
             nprocs=1,
             tStop=T_STOP_SHORT,
@@ -70,12 +71,12 @@ def test_run_new_simulations_returns_dirname(tmpdir):
     assert isinstance(result[0][0], str)
 
 
-def test_position_of_morphology_does_not_matter_after_network_mapping(tmpdir, client):
+def test_position_of_morphology_does_not_matter_after_network_mapping(tmp_path, client):
     # simrun renames a dir once it finishes running
     # so create single-purpose subdirectories for simulation output
-    subdir1 = tmpdir.mkdir("sub1")
-    subdir2 = tmpdir.mkdir("sub2")
-    subdir_params = tmpdir.mkdir("params")
+    subdir1 = tmp_path.mkdir("sub1")
+    subdir2 = tmp_path.mkdir("sub2")
+    subdir_params = tmp_path.mkdir("params")
     syn_act_fn = SYN_ACT_SUBSAMPLED_FN
     t_stop = T_STOP_SHORT
     
@@ -127,7 +128,7 @@ def test_position_of_morphology_does_not_matter_after_network_mapping(tmpdir, cl
         raise
 
 
-def test_reproduce_simulation_trial_from_roberts_model_control(tmpdir, client):
+def test_reproduce_simulation_trial_from_roberts_model_control(tmp_path, client):
     # Note: these tolerances were found with trial and error, but have no further meaning
     if sys.platform.startswith('linux'):
         n_decimals=3
@@ -144,7 +145,7 @@ def test_reproduce_simulation_trial_from_roberts_model_control(tmpdir, client):
         dummy = simrun.run_existing_synapse_activations.run_existing_synapse_activations(
             NEUP_FN,
             NETP_FN, [syn_act_fn],
-            dirPrefix=tmpdir.dirname,
+            dirPrefix=tmp_path,
             nprocs=1,
             tStop=345,
             silent=True,

--- a/tests/test_simrun/simrun_test.py
+++ b/tests/test_simrun/simrun_test.py
@@ -74,9 +74,13 @@ def test_run_new_simulations_returns_dirname(tmp_path):
 def test_position_of_morphology_does_not_matter_after_network_mapping(tmp_path, client):
     # simrun renames a dir once it finishes running
     # so create single-purpose subdirectories for simulation output
-    subdir1 = tmp_path.mkdir("sub1")
-    subdir2 = tmp_path.mkdir("sub2")
-    subdir_params = tmp_path.mkdir("params")
+    subdir1 = tmp_path / "sub1"
+    subdir2 = tmp_path / "sub2"
+    subdir_params = tmp_path / "params"
+    subdir1.mkdir()
+    subdir2.mkdir()
+    subdir_params.mkdir()
+
     syn_act_fn = SYN_ACT_SUBSAMPLED_FN
     t_stop = T_STOP_SHORT
     
@@ -145,7 +149,7 @@ def test_reproduce_simulation_trial_from_roberts_model_control(tmp_path, client)
         dummy = simrun.run_existing_synapse_activations.run_existing_synapse_activations(
             NEUP_FN,
             NETP_FN, [syn_act_fn],
-            dirPrefix=tmp_path,
+            dirPrefix=str(tmp_path),
             nprocs=1,
             tStop=345,
             silent=True,


### PR DESCRIPTION
Tests don't run on some windows machines, because the combination of long filenames in `simrun` (such as dendritic voltage traces) and long pytest `tmpdir` directories (i.e. `{temproot}/pytest-of-{user}/pytest-{num}/{testname}/`) quickly exceed the `260` character limit imposed on most windows machines. Rather than requiring users to mess with the registry, I implemented a different default `basetmp` for windows.

Other fix: No more verbose error output for `spiketrain` creation. See #360 