### PR TITLE
[PERF] Vectorize `singlecell_input_mapper.map_singlecell_inputs`

### DIFF
--- a/single_cell_parser/reader.py
+++ b/single_cell_parser/reader.py
@@ -22,6 +22,7 @@ See also:
 '''
 
 import numpy as np
+import re
 from . import scalar_field
 from data_base.dbopen import dbopen
 import logging
@@ -258,68 +259,65 @@ def read_hoc_file(fname=''):
         return cell
 
 
-def read_scalar_field(fname=''):
-    """Read AMIRA scalar fields.
+def read_scalar_field(fname='', dtype=np.float64):
+    """Read ASCII AMIRA scalar field mesh files with high speed.
+    
+    This function reads in AMIRA scalar fields. Particular attention is given to speeding up reading of 
+    the actual data.
     
     Args:
-        fname (str): The name of the file to be read.
+        fname (str): Filename of the Amira Mesh file to be read.
+        dtype (numpy.dtype): Data type of the scalar field, default is `np.float64`.
 
     Raises:
         IOError: If the input file does not have a `.am` or `.AM` suffix.
-
+        
     Returns:
-        :py:class:`~single_cell_parser.scalar_field.ScalarField`: A scalar field object.
+        :py:class:`~single_cell_parser.scalar_field.ScalarField`: A scalar field object containing the mesh data, origin, extent, spacing, and bounds.
     """
-    if not fname.endswith('.am') and not fname.endswith('.AM'):
+    if not fname.endswith(('.am', '.AM')):
         raise IOError('Input file is not an Amira Mesh file!')
 
     with dbopen(fname, 'r') as meshFile:
-        # logger.info "Reading Amira Mesh file", fname
         mesh = None
-        extent, dims, bounds, origin, spacing = [], [], [], [], [0., 0., 0.]
-        dataSection, hasExtent, hasBounds = False, False, False
-        index = 0
+        extent, dims, bounds, origin, spacing = [], [], [], [], []
+        header_lines = []
+
+        # Read until we reach the data section
         for line in meshFile:
-            if line.strip():
-                # set up lattice
-                if not dataSection:
-                    if 'define' in line and 'Lattice' in line:
-                        dimStr = line.strip().split()[-3:]
-                        for dim in dimStr:
-                            dims.append(int(dim))
-                        for dim in dims:
-                            extent.append(0)
-                            extent.append(dim - 1)
-                        hasExtent = True
-                    if 'BoundingBox' in line:
-                        bBoxStr = line.strip(' \t\n,').split()[-6:]
-                        for val in bBoxStr:
-                            bounds.append(float(val))
-                        for i in range(3):
-                            origin.append(bounds[2 * i])
-                        hasBounds = True
-                    if hasExtent and hasBounds and mesh is None:
-                        for i in range(3):
-                            spacing[i] = (bounds[2 * i + 1] - bounds[2 * i]) / (
-                                extent[2 * i + 1] - extent[2 * i])
-                            bounds[2 * i + 1] += 0.5 * spacing[i]
-                            bounds[2 * i] -= 0.5 * spacing[i]
-                            origin[i] -= 0.5 * spacing[i]
-                        mesh = np.empty(shape=dims)
-                    if '@1' in line and line[:2] == '@1':
-                        dataSection = True
-                        continue
-                # main data loop
-                else:
-                    data = float(line.strip())
-                    k = index // (dims[0] * dims[1])
-                    j = index // dims[0] - dims[1] * k
-                    i = index - dims[0] * (j + dims[1] * k)
-                    mesh[i, j, k] = data
-                    index += 1
-                    # logger.info 'i,j,k = %s,%s,%s' % (i, j, k)
+            header_lines.append(line)
+            if line.strip().startswith('@1'):
+                break
+
+        # Parse header info
+        for line in header_lines:
+            line = line.strip()
+            if not line:
+                continue
+            if 'define' in line and 'Lattice' in line:
+                dims = list(map(int, line.split()[-3:]))
+                extent = [v for dim in dims for v in (0, dim - 1)]
+            elif 'BoundingBox' in line:
+                bounds = list(map(float, line.strip(' \t\n,').split()[-6:]))
+                origin = [bounds[2 * i] for i in range(3)]
+            elif 'Spacing' in line:
+                spacing = list(map(float, line.strip(' \t\n,').split()[-3:]))
+
+        # Adjust bounds/origin before reading the data section
+        for i in range(3):
+            bounds[2 * i + 1] += 0.5 * spacing[i]
+            bounds[2 * i] -= 0.5 * spacing[i]
+            origin[i] -= 0.5 * spacing[i]
+
+        # Read the remainder of the file as one string and convert to float64
+        data_str = meshFile.read()
+        data = np.fromstring(data_str, sep=' ', dtype=dtype)
+
+        # Reshape into a 3D array in Fortran order
+        mesh = data.reshape(dims, order='F')
 
         return scalar_field.ScalarField(mesh, origin, extent, spacing, bounds)
+
 
 
 def read_synapse_realization(fname):
@@ -756,6 +754,77 @@ def read_landmark_file(landmarkFilename):
                 landmarks.append((x, y, z))
 
     return landmarks
+
+
+# Old versions ---------------------------------------------------
+
+def read_scalar_field_legacy(fname=''):
+    """Read AMIRA scalar fields.
+    
+    Args:
+        fname (str): The name of the file to be read.
+
+    Raises:
+        IOError: If the input file does not have a `.am` or `.AM` suffix.
+
+    Returns:
+        :py:class:`~single_cell_parser.scalar_field.ScalarField`: A scalar field object.
+
+    .. deprecated:: 0.5.0
+       This has been deprecated in favor of the faster :py:meth:`read_scalar_field`
+
+    :skip-doc:
+    """
+    if not fname.endswith('.am') and not fname.endswith('.AM'):
+        raise IOError('Input file is not an Amira Mesh file!')
+
+    with dbopen(fname, 'r') as meshFile:
+        # logger.info "Reading Amira Mesh file", fname
+        mesh = None
+        extent, dims, bounds, origin, spacing = [], [], [], [], [0., 0., 0.]
+        dataSection, hasExtent, hasBounds = False, False, False
+        index = 0
+        for line in meshFile:
+            if line.strip():
+                # set up lattice
+                if not dataSection:
+                    if 'define' in line and 'Lattice' in line:
+                        dimStr = line.strip().split()[-3:]
+                        for dim in dimStr:
+                            dims.append(int(dim))
+                        for dim in dims:
+                            extent.append(0)
+                            extent.append(dim - 1)
+                        hasExtent = True
+                    if 'BoundingBox' in line:
+                        bBoxStr = line.strip(' \t\n,').split()[-6:]
+                        for val in bBoxStr:
+                            bounds.append(float(val))
+                        for i in range(3):
+                            origin.append(bounds[2 * i])
+                        hasBounds = True
+                    if hasExtent and hasBounds and mesh is None:
+                        for i in range(3):
+                            spacing[i] = (bounds[2 * i + 1] - bounds[2 * i]) / (
+                                extent[2 * i + 1] - extent[2 * i])
+                            bounds[2 * i + 1] += 0.5 * spacing[i]
+                            bounds[2 * i] -= 0.5 * spacing[i]
+                            origin[i] -= 0.5 * spacing[i]
+                        mesh = np.empty(shape=dims)
+                    if '@1' in line and line[:2] == '@1':
+                        dataSection = True
+                        continue
+                # main data loop
+                else:
+                    data = float(line.strip())
+                    k = index // (dims[0] * dims[1])
+                    j = index // dims[0] - dims[1] * k
+                    i = index - dims[0] * (j + dims[1] * k)
+                    mesh[i, j, k] = data
+                    index += 1
+                    # logger.info 'i,j,k = %s,%s,%s' % (i, j, k)
+
+        return scalar_field.ScalarField(mesh, origin, extent, spacing, bounds)
 
 
 if __name__ == '__main__':

--- a/single_cell_parser/reader.py
+++ b/single_cell_parser/reader.py
@@ -125,7 +125,7 @@ def read_hoc_file(fname=''):
 
 
     with dbopen(fname, 'r') as neuronFile:
-        logger.info("Reading hoc file %s" % fname)
+        logger.info("Reading hoc file: {}".format(fname))
         #        cell = co.Cell()
         #        simply store list of edges
         #        cell is parsed in CellParser

--- a/single_cell_parser/scalar_field.py
+++ b/single_cell_parser/scalar_field.py
@@ -90,38 +90,64 @@ class ScalarField(object):
         if self.mesh is not None:
             self.resize_mesh()
 
-    def resize_mesh(self):
-        '''Resizes mesh to non-zero scalar data.
+    # def resize_mesh(self):
+    #     '''Resizes mesh to non-zero scalar data.
          
-        This method resizes the mesh such that the bounding box 
-        wraps around voxels that contain non-zero scalar data.
-        Also updates :py:attr:`extent` and :py:attr:`boundingBox`
-        '''
-        roi = np.nonzero(self.mesh)
-        iMin = np.min(roi[0])
-        iMax = np.max(roi[0])
-        jMin = np.min(roi[1])
-        jMax = np.max(roi[1])
-        kMin = np.min(roi[2])
-        kMax = np.max(roi[2])
-        self.extent = 0, iMax - iMin, 0, jMax - jMin, 0, kMax - kMin
-        newDims = self.extent[1] + 1, self.extent[3] + 1, self.extent[5] + 1
-        dx = self.spacing[0]
-        dy = self.spacing[1]
-        dz = self.spacing[2]
-        xMin = self.origin[0] + iMin * dx
-        yMin = self.origin[1] + jMin * dy
-        zMin = self.origin[2] + kMin * dz
-        xMax = self.origin[0] + iMax * dx
-        yMax = self.origin[1] + jMax * dy
-        zMax = self.origin[2] + kMax * dz
-        self.origin = xMin, yMin, zMin
-        self.boundingBox = xMin, xMax, yMin, yMax, zMin, zMax
-        newMesh = np.empty(shape=newDims)
-        newMesh[:, :, :] = self.mesh[iMin:iMax + 1, jMin:jMax + 1,
-                                     kMin:kMax + 1]
-        self.mesh = np.copy(newMesh)
-        del newMesh
+    #     This method resizes the mesh such that the bounding box 
+    #     wraps around voxels that contain non-zero scalar data.
+    #     Also updates :py:attr:`extent` and :py:attr:`boundingBox`
+    #     '''
+    #     roi = np.nonzero(self.mesh)
+    #     iMin = np.min(roi[0])
+    #     iMax = np.max(roi[0])
+    #     jMin = np.min(roi[1])
+    #     jMax = np.max(roi[1])
+    #     kMin = np.min(roi[2])
+    #     kMax = np.max(roi[2])
+    #     self.extent = 0, iMax - iMin, 0, jMax - jMin, 0, kMax - kMin
+    #     newDims = self.extent[1] + 1, self.extent[3] + 1, self.extent[5] + 1
+    #     dx = self.spacing[0]
+    #     dy = self.spacing[1]
+    #     dz = self.spacing[2]
+    #     xMin = self.origin[0] + iMin * dx
+    #     yMin = self.origin[1] + jMin * dy
+    #     zMin = self.origin[2] + kMin * dz
+    #     xMax = self.origin[0] + iMax * dx
+    #     yMax = self.origin[1] + jMax * dy
+    #     zMax = self.origin[2] + kMax * dz
+    #     self.origin = xMin, yMin, zMin
+    #     self.boundingBox = xMin, xMax, yMin, yMax, zMin, zMax
+    #     newMesh = np.empty(shape=newDims)
+    #     newMesh[:, :, :] = self.mesh[iMin:iMax + 1, jMin:jMax + 1,
+    #                                  kMin:kMax + 1]
+    #     self.mesh = np.copy(newMesh)
+    #     del newMesh
+
+    def resize_mesh(self):
+        """Resizes mesh to non-zero scalar data using slicing views (no copy)."""
+        roi = np.where(self.mesh)
+        if roi[0].size == 0:
+            return  # no non-zero voxels
+
+        iMin, iMax = roi[0].min(), roi[0].max()
+        jMin, jMax = roi[1].min(), roi[1].max()
+        kMin, kMax = roi[2].min(), roi[2].max()
+
+        self.extent = (0, iMax - iMin, 0, jMax - jMin, 0, kMax - kMin)
+
+        dx, dy, dz = self.spacing
+        xMin, yMin, zMin = (self.origin[0] + iMin * dx,
+                            self.origin[1] + jMin * dy,
+                            self.origin[2] + kMin * dz)
+        xMax, yMax, zMax = (self.origin[0] + (iMax + 1) * dx,
+                            self.origin[1] + (jMax + 1) * dy,
+                            self.origin[2] + (kMax + 1) * dz)
+
+        self.origin = (xMin, yMin, zMin)
+        self.boundingBox = (xMin, xMax, yMin, yMax, zMin, zMax)
+
+        # Slice view instead of copying
+        self.mesh = self.mesh[iMin:iMax + 1, jMin:jMax + 1, kMin:kMax + 1]
 
     def get_scalar(self, xyz):
         '''Fetch the scalar value of the voxel containing the point xyz.

--- a/singlecell_input_mapper/map_singlecell_inputs.py
+++ b/singlecell_input_mapper/map_singlecell_inputs.py
@@ -222,13 +222,15 @@ def map_singlecell_inputs(
     numberOfCellsSpreadsheet = sim.read_celltype_numbers_spreadsheet(
         numberOfCellsSpreadsheetName
     )
-    logger.info(
+    logger.debug("    numberOfCells spreadsheet loaded".format(numberOfCellsSpreadsheetName))
+    logger.debug(
         "    Loading connections spreadsheet {:s}".format(connectionsSpreadsheetName)
     )
     connectionsSpreadsheet = sim.read_connections_spreadsheet(
         connectionsSpreadsheetName
     )
-    logger.info("    Loading PST density {:s}".format(ExPSTDensityName))
+    logger.debug("    Connections spreadsheet loaded")
+    logger.debug("    Loading PST density {:s}".format(ExPSTDensityName))
     ExPSTDensity = sim.read_scalar_field(ExPSTDensityName)
     ExPSTDensity.resize_mesh()
     logger.info("    Loading PST density {:s}".format(InhPSTDensityName))
@@ -249,7 +251,7 @@ def map_singlecell_inputs(
             boutonDensityFolder = os.path.join(
                 boutonDensityFolderName, anatomical_area, preCellType
             )
-            assert os.path.exists(boutonDensityFolder), "Could not find bouton density folders of the barrel cortex model. Did you download and extract the barrel cortex model?"
+            assert os.path.exists(boutonDensityFolder), "Could not find bouton density folder: {}".format(boutonDensityFolder)
             boutonDensityNames = glob.glob(os.path.join(boutonDensityFolder, "*"))
             logger.debug(
                 "    Loading {:d} bouton densities from {:s}".format(
@@ -271,6 +273,7 @@ def map_singlecell_inputs(
     )
     inputMapper.exCellTypes = exTypes
     inputMapper.inhCellTypes = inhTypes
+    logger.info("Creating network embedding for  {:s}".format(cellName))
     inputMapper.create_network_embedding(
         cellName, boutonDensities, nrOfSamples=nrOfSamples
     )

--- a/singlecell_input_mapper/map_singlecell_inputs.py
+++ b/singlecell_input_mapper/map_singlecell_inputs.py
@@ -214,55 +214,43 @@ def map_singlecell_inputs(
 
     # --------------------- Read in data ---------------------
     logger.info("Loading spreadsheets and bouton/PST densities...")
-    logger.info(
-        "    Loading numberOfCells spreadsheet {:s}".format(
-            numberOfCellsSpreadsheetName
-        )
-    )
-    numberOfCellsSpreadsheet = sim.read_celltype_numbers_spreadsheet(
-        numberOfCellsSpreadsheetName
-    )
+
+    logger.info("    Loading numberOfCells spreadsheet {:s}".format(numberOfCellsSpreadsheetName))
+    numberOfCellsSpreadsheet = sim.read_celltype_numbers_spreadsheet(numberOfCellsSpreadsheetName)
     logger.debug("    numberOfCells spreadsheet loaded".format(numberOfCellsSpreadsheetName))
-    logger.debug(
-        "    Loading connections spreadsheet {:s}".format(connectionsSpreadsheetName)
-    )
-    connectionsSpreadsheet = sim.read_connections_spreadsheet(
-        connectionsSpreadsheetName
-    )
+
+    logger.debug("    Loading connections spreadsheet {:s}".format(connectionsSpreadsheetName))
+    connectionsSpreadsheet = sim.read_connections_spreadsheet(connectionsSpreadsheetName)
     logger.debug("    Connections spreadsheet loaded")
+
     logger.debug("    Loading PST density {:s}".format(ExPSTDensityName))
     ExPSTDensity = sim.read_scalar_field(ExPSTDensityName)
     ExPSTDensity.resize_mesh()
     logger.info("    Loading PST density {:s}".format(InhPSTDensityName))
     InhPSTDensity = sim.read_scalar_field(InhPSTDensityName)
     InhPSTDensity.resize_mesh()
+
+
     boutonDensities = {}
     anatomical_areas = list(numberOfCellsSpreadsheet.keys())
     preCellTypes = numberOfCellsSpreadsheet[anatomical_areas[0]]
 
     # --------------------- Load bouton densities ---------------------
+    logger.info("Loading bouton densities from folder {:s} (may take a while)".format(boutonDensityFolderName))
     for anatomical_area in anatomical_areas:
-        # boutonDensities is a dictionary with anatomical areas as keys
-        # and as value another dictionary mapping the presyn celltype to
-        # scalar fields of boutons
-        boutonDensities[anatomical_area] = {}
+        boutonDensities[anatomical_area] = {}  # type is Dict[str, Dict[str, List[scim.ScalarField]]]
         for preCellType in preCellTypes:
-            boutonDensities[anatomical_area][preCellType] = []
-            boutonDensityFolder = os.path.join(
-                boutonDensityFolderName, anatomical_area, preCellType
-            )
+            boutonDensities[anatomical_area][preCellType] = [] # type is List[scim.ScalarField]
+            boutonDensityFolder = os.path.join(boutonDensityFolderName, anatomical_area, preCellType)
             assert os.path.exists(boutonDensityFolder), "Could not find bouton density folder: {}".format(boutonDensityFolder)
             boutonDensityNames = glob.glob(os.path.join(boutonDensityFolder, "*"))
-            logger.debug(
-                "    Loading {:d} bouton densities from {:s}".format(
-                    len(boutonDensityNames), boutonDensityFolder
-                )
-            )
+            logger.debug("    Loading {:d} bouton densities from {:s}".format(len(boutonDensityNames), boutonDensityFolder))
             for densityName in boutonDensityNames:
                 boutonDensity = sim.read_scalar_field(densityName)
                 boutonDensity.resize_mesh()
                 boutonDensities[anatomical_area][preCellType].append(boutonDensity)
 
+    # Actually create the network embedding
     inputMapper = sim.NetworkMapper(
         singleCell,
         cellTypeName,
@@ -273,11 +261,11 @@ def map_singlecell_inputs(
     )
     inputMapper.exCellTypes = exTypes
     inputMapper.inhCellTypes = inhTypes
-    logger.info("Creating network embedding for  {:s}".format(cellName))
-    inputMapper.create_network_embedding(
-        cellName, boutonDensities, nrOfSamples=nrOfSamples
-    )
 
+    logger.info("Creating network embedding for  {:s}".format(cellName))
+    inputMapper.create_network_embedding(cellName, boutonDensities, nrOfSamples=nrOfSamples)
+
+    # Record time and write summary
     endTime = time.time()
     duration = (endTime - startTime) / 60.0
     logger.info("Runtime: {:.1f} minutes".format(duration))

--- a/singlecell_input_mapper/singlecell_input_mapper/network_embedding.py
+++ b/singlecell_input_mapper/singlecell_input_mapper/network_embedding.py
@@ -125,28 +125,29 @@ class NetworkMapper:
         self._create_presyn_cells()
         anatomical_areas = list(self.cells.keys())
         preCellTypes = self.cells[anatomical_areas[0]]
-        cellTypeSynapseDensities = self._precompute_anatomical_area_celltype_synapse_densities(
-            boutonDensities)
+        logger.info("Computing synapse densities")
+        cellTypeSynapseDensities = self._precompute_anatomical_area_celltype_synapse_densities_vectorized(boutonDensities)
         sampleConnectivityData = []
         cellTypeSpecificPopulation = []
         for i in range(nrOfSamples):
-            logger.info('Generating network embedding sample {:d}'.format(i))
+
+            logger.info('Generating network embedding sample {:d} of {:d}'.format(i, nrOfSamples))
             self.postCell.remove_synapses('All')
             for anatomical_area in anatomical_areas:
                 for preCellType in preCellTypes:
                     for preCell in self.cells[anatomical_area][preCellType]:
                         preCell.synapseList = None
+            
+            logger.debug("    Sample {:d} of {:d}: Creating anatomical realization...".format(i + 1, nrOfSamples))
             connectivityMap, connectedCells, connectedCellsPerStructure = \
                 self._create_anatomical_realization(cellTypeSynapseDensities)
-            (
-                synapseLocations,
-                cellSynapseLocations, 
-                cellTypeSummaryTable, 
-                anatomicalAreaSummaryTable
-            ) = self._compute_summary_tables(
-                connectedCells, 
-                connectedCellsPerStructure
-            )
+            logger.debug("    Sample {:d} of {:d}: Anatomical realization done.".format(i + 1, nrOfSamples))
+            
+            logger.debug("    Sample {:d} of {:d}: Computing summary tables...".format(i + 1, nrOfSamples))
+            synapseLocations, cellSynapseLocations,cellTypeSummaryTable, anatomicalAreaSummaryTable = \
+                self._compute_summary_tables(connectedCells, connectedCellsPerStructure)
+            logger.debug("    Sample {:d} of {:d}: Computing summary tables done".format(i + 1, nrOfSamples))
+
             connectivityData = connectivityMap, synapseLocations, \
                                 cellSynapseLocations, cellTypeSummaryTable,\
                                 anatomicalAreaSummaryTable
@@ -158,6 +159,7 @@ class NetworkMapper:
             cellTypeSpecificPopulation)
         representativeIndex = self._get_representative_sample(
             cellTypeSpecificPopulation, populationDistribution)
+        logger.info("Writing output files for representative sample (id={})".format(representativeIndex))
         (connectivityMap, 
          synapseLocations, 
          cellSynapseLocations, 
@@ -223,8 +225,7 @@ class NetworkMapper:
 
         cellTypeSpecificPopulation = []
         for i in range(nrOfRealizations):
-            logger.info('Creating realization {:d} of {:d}'.format(
-                i + 1, nrOfRealizations))
+            logger.info('Creating realization {:d} of {:d}'.format(i + 1, nrOfRealizations))
             self.postCell.remove_synapses('All')
             for anatomical_area in anatomical_areas:
                 for preCellType in preCellTypes:
@@ -322,8 +323,8 @@ class NetworkMapper:
         cellTypeSynapseDensities = synapseDensities
         for anatomical_area in anatomical_areas:
             for preCellType in preCellTypes:
-                logger.info('---------------------------')
-                logger.info('Assigning synapses from cell type {:s} in anatomical_area {:s}'.
+                logger.debug('---------------------------')
+                logger.debug('    Assigning synapses from cell type {:s} in anatomical_area {:s}'.
                       format(preCellType, anatomical_area))
                 nrOfDensities = len(cellTypeSynapseDensities[anatomical_area][preCellType])
                 if not nrOfDensities:
@@ -332,9 +333,7 @@ class NetworkMapper:
                 count = 0
                 for preCell in self.cells[anatomical_area][preCellType]:
                     count += 1
-                    logger.info(
-                        '    Computing synapses for presynaptic cell {:d} of {:d}...\r'
-                        .format(count, totalNumber))  #, end=' ')
+                    logger.debug('    Computing synapses for presynaptic cell {:d} of {:d}...\r'.format(count, totalNumber))  #, end=' ')
                     sys.stdout.flush()
                     densityID = np.random.randint(nrOfDensities)
                     synapseDensity = cellTypeSynapseDensities[anatomical_area][preCellType][
@@ -345,7 +344,7 @@ class NetworkMapper:
                         synapseType)
                     for newSyn in preCell.synapseList:
                         newSyn.preCell = preCell
-                logger.info('')
+                logger.debug('')
 
         connectivityMap, connectedCells, connectedCellsPerStructure = \
             self._create_anatomical_connectivity_map()
@@ -358,6 +357,39 @@ class NetworkMapper:
         logger.info('---------------------------')
 
     def _precompute_anatomical_area_celltype_synapse_densities(self, boutonDensities):
+        '''Compute synapse densities of all presynaptic cell types in all anatomical_areas
+        
+        Computes all possible synapse densities that have non-zero overlap
+        with the current postynaptic neuron, and sorts them based on presynaptic anatomical_area and cell type
+
+        .. deprecated:: 0.5.0
+           This has been deprecated in favor of :py:meth:`_precompute_anatomical_area_celltype_synapse_densities_vectorized`
+
+        :skip-doc:
+        '''
+        synapseDensities = {}
+        synapseDensityComputation = SynapseDensity(
+            self.postCell, 
+            self.postCellType, 
+            self.connectionsSpreadsheet,
+            self.exCellTypes, 
+            self.inhCellTypes, 
+            self.exPST, 
+            self.inhPST)
+        anatomical_areas = list(boutonDensities.keys())
+        preCellTypes = boutonDensities[anatomical_areas[0]]
+        for anatomical_area in anatomical_areas:
+            synapseDensities[anatomical_area] = {}
+            for preCellType in preCellTypes:
+                synapseDensities[anatomical_area][preCellType] = []
+                logger.debug('Computing synapse densities from cell type {:s} in {:s}'.format(preCellType, anatomical_area))
+                for boutons in boutonDensities[anatomical_area][preCellType]:
+                    synapseDensities[anatomical_area][preCellType].append(
+                        synapseDensityComputation.compute_synapse_density(
+                            boutons, preCellType))
+        return synapseDensities
+
+    def _precompute_anatomical_area_celltype_synapse_densities_vectorized(self, boutonDensities):
         '''Compute synapse densities of all presynaptic cell types in all anatomical_areas
         
         Computes all possible synapse densities that have non-zero overlap
@@ -378,15 +410,11 @@ class NetworkMapper:
             synapseDensities[anatomical_area] = {}
             for preCellType in preCellTypes:
                 synapseDensities[anatomical_area][preCellType] = []
-                logger.info('---------------------------')
-                logger.info(
-                    'Computing synapse densities from cell type %s in anatomical_area {:s}'
-                    .format(preCellType, anatomical_area))
+                logger.debug('Computing synapse densities from cell type {:s} in {:s}'.format(preCellType, anatomical_area))
                 for boutons in boutonDensities[anatomical_area][preCellType]:
                     synapseDensities[anatomical_area][preCellType].append(
-                        synapseDensityComputation.compute_synapse_density(
+                        synapseDensityComputation.compute_synapse_density_vectorized(
                             boutons, preCellType))
-        logger.info('---------------------------')
         return synapseDensities
 
     def _create_presyn_cells(self):
@@ -410,9 +438,7 @@ class NetworkMapper:
                     newCell = PointCell(anatomical_area, cellType)
                     self.cells[anatomical_area][cellType].append(newCell)
                     cellIDs += 1
-                logger.info(
-                    '    Created {:d} presynaptic cells of type {:s} in anatomical_area {:s}'
-                    .format(nrOfCellsPerType, cellType, anatomical_area))
+                logger.debug('    Created {:d} presynaptic cells of type {:s} in anatomical_area {:s}'.format(nrOfCellsPerType, cellType, anatomical_area))
         logger.info('Created {:d} presynaptic cells in total'.format(cellIDs))
         logger.info('---------------------------')
 
@@ -421,7 +447,7 @@ class NetworkMapper:
 
         This is the main method for computing synapse/connectivity realization.
         Given one or more pre-computed density fields of synapses (see e.g. 
-        :py:meth:`~_precompute_anatomical_area_celltype_synapse_densities`), this method 
+        :py:meth:`~_precompute_anatomical_area_celltype_synapse_densities_vectorized`), this method 
         creates a :py:class:`~singlecell_input_mapper.singlecell_input_mapper.synapse_mapper.SynapseMapper`
         from this synapse density field, and assigns synapses.
 
@@ -446,11 +472,9 @@ class NetworkMapper:
                 #         synapseDensityName = '_'.join((outNamePrefix,'synapse_density',structure,anatomical_area,preCellType,str(i)))
                 #         writer.write_scalar_field(synapseDensityName, outDensity)
 
-                logger.info('---------------------------')
-                logger.info(
-                    'Computed {:d} synapse densities of type {:s} in anatomical_area {:s}!'
-                    .format(nrOfDensities, preCellType, anatomical_area))
-                logger.info('Assigning synapses from cell type {:s} in anatomical_area {:s}'.
+                logger.debug('---------------------------')
+                logger.debug('Computed {:d} synapse densities of type {:s} in anatomical_area {:s}'.format(nrOfDensities, preCellType, anatomical_area))
+                logger.debug('Assigning synapses from cell type {:s} in anatomical_area {:s}'.
                       format(preCellType, anatomical_area))
                 totalNumber = len(self.cells[anatomical_area][preCellType])
                 densityIDs = np.random.randint(0, nrOfDensities, totalNumber)
@@ -459,10 +483,8 @@ class NetworkMapper:
                 for i in range(totalNumber):
                     preCell = self.cells[anatomical_area][preCellType][i]
                     count += 1
-                    logger.info(
-                        '    Computing synapses for presynaptic cell {:d} of {:d}...\r'
-                        .format(count, totalNumber))  #, end=' ')
-                    sys.stdout.flush()
+                    logger.debug('    Computing synapses for presynaptic cell {:d} of {:d}...\r'.format(count, totalNumber))  #, end=' ')
+                    # sys.stdout.flush()
                     densityID = densityIDs[i]
                     synapseDensity = cellTypeSynapseDensities[anatomical_area][preCellType][densityID]
                     if synapseDensity is None:
@@ -473,8 +495,8 @@ class NetworkMapper:
                     preCell.synapseList = self.mapper.create_synapses(synapseType)
                     for newSyn in preCell.synapseList:
                         newSyn.preCell = preCell
-                logger.info('')
-                logger.info('    Skipped {:d} empty synapse densities...'.format(skipCount))
+                logger.debug('')
+                logger.debug('    Skipped {:d} empty synapse densities...'.format(skipCount))
 
         return self._create_anatomical_connectivity_map()
 

--- a/singlecell_input_mapper/singlecell_input_mapper/network_embedding.py
+++ b/singlecell_input_mapper/singlecell_input_mapper/network_embedding.py
@@ -21,6 +21,7 @@ this module does not handle the activity of presynaptic populations, but provide
 
 '''
 from __future__ import absolute_import
+from typing import Dict
 import os
 import sys
 import time
@@ -144,7 +145,7 @@ class NetworkMapper:
             logger.debug("    Sample {:d} of {:d}: Anatomical realization done.".format(i + 1, nrOfSamples))
             
             logger.debug("    Sample {:d} of {:d}: Computing summary tables...".format(i + 1, nrOfSamples))
-            synapseLocations, cellSynapseLocations,cellTypeSummaryTable, anatomicalAreaSummaryTable = \
+            synapseLocations, cellSynapseLocations, cellTypeSummaryTable, anatomicalAreaSummaryTable = \
                 self._compute_summary_tables(connectedCells, connectedCellsPerStructure)
             logger.debug("    Sample {:d} of {:d}: Computing summary tables done".format(i + 1, nrOfSamples))
 
@@ -362,6 +363,10 @@ class NetworkMapper:
         Computes all possible synapse densities that have non-zero overlap
         with the current postynaptic neuron, and sorts them based on presynaptic anatomical_area and cell type
 
+        Args:
+            boutonDensities (Dict[str, Dict[str, List[:py:class:`~singlecell_input_mapper.singlecell_input_mapper.scalar_field.ScalarField`]]]):
+                Dictionary of bouton densities, ordered by anatomical area and cell type.
+
         .. deprecated:: 0.5.0
            This has been deprecated in favor of :py:meth:`_precompute_anatomical_area_celltype_synapse_densities_vectorized`
 
@@ -394,6 +399,10 @@ class NetworkMapper:
         
         Computes all possible synapse densities that have non-zero overlap
         with the current postynaptic neuron, and sorts them based on presynaptic anatomical_area and cell type
+
+        Args:
+            boutonDensities (Dict[str, Dict[str, :py:class:`~singlecell_input_mapper.singlecell_input_mapper.scalar_field.ScalarField`]]):
+                Dictionary of bouton densities, ordered by anatomical area and cell type.
         '''
         synapseDensities = {}
         synapseDensityComputation = SynapseDensity(
@@ -413,8 +422,7 @@ class NetworkMapper:
                 logger.debug('Computing synapse densities from cell type {:s} in {:s}'.format(preCellType, anatomical_area))
                 for boutons in boutonDensities[anatomical_area][preCellType]:
                     synapseDensities[anatomical_area][preCellType].append(
-                        synapseDensityComputation.compute_synapse_density_vectorized(
-                            boutons, preCellType))
+                        synapseDensityComputation.compute_synapse_density_vectorized(boutons, preCellType))
         return synapseDensities
 
     def _create_presyn_cells(self):
@@ -432,8 +440,7 @@ class NetworkMapper:
             self.cells[anatomical_area] = {}
             for cellType in cellTypes:
                 self.cells[anatomical_area][cellType] = []
-                nrOfCellsPerType = self.cellTypeNumbersSpreadsheet[anatomical_area][
-                    cellType]
+                nrOfCellsPerType = self.cellTypeNumbersSpreadsheet[anatomical_area][cellType]
                 for i in range(nrOfCellsPerType):
                     newCell = PointCell(anatomical_area, cellType)
                     self.cells[anatomical_area][cellType].append(newCell)
@@ -1013,7 +1020,7 @@ class NetworkMapper:
                 if nrOfApicalSynapses + nrOfBasalSynapses + nrOfSomaSynapses != nrOfSynapses:
                     errstr = 'Logical error: Number of synapses does not add up'
                     raise RuntimeError(errstr)
-                logger.info('    Created {:d} synapses of type {:s}!'.format(
+                logger.debug('    Created {:d} synapses of type {:s}!'.format(
                     nrOfSynapses, preCellType))
                 #===============================================================
                 # anatomical_area- and cell type-specific data

--- a/singlecell_input_mapper/singlecell_input_mapper/reader.py
+++ b/singlecell_input_mapper/singlecell_input_mapper/reader.py
@@ -19,6 +19,7 @@
 '''
 
 import numpy as np
+from config.isf_logging import logger
 from . import scalar_field
 from data_base.dbopen import dbopen
 
@@ -84,7 +85,7 @@ def read_hoc_file(fname=''):
         raise IOError('Input file is not a .hoc file!')
 
     with dbopen(fname, 'r') as neuronFile:
-        print("Reading hoc file", fname)
+        logger.info("Reading hoc file", fname)
         # cell = co.Cell()
         # simply store list of edges
         # cell is parsed in CellParser
@@ -222,7 +223,68 @@ def read_hoc_file(fname=''):
         return cell
 
 
-def read_scalar_field(fname=''):
+
+def read_scalar_field(fname='', dtype=np.float64):
+    """Read ASCII AMIRA scalar field mesh files with high speed.
+    
+    This function reads in AMIRA scalar fields. Particular attention is given to speeding up reading of 
+    the actual data.
+    
+    Args:
+        fname (str): Filename of the Amira Mesh file to be read.
+        dtype (numpy.dtype): Data type of the scalar field, default is `np.float64`.
+
+    Raises:
+        IOError: If the input file does not have a `.am` or `.AM` suffix.
+        
+    Returns:
+        :py:class:`~single_cell_parser.scalar_field.ScalarField`: A scalar field object containing the mesh data, origin, extent, spacing, and bounds.
+    """
+    if not fname.endswith(('.am', '.AM')):
+        raise IOError('Input file is not an Amira Mesh file!')
+
+    with dbopen(fname, 'r') as meshFile:
+        mesh = None
+        extent, dims, bounds, origin, spacing = [], [], [], [], []
+        header_lines = []
+
+        # Read until we reach the data section
+        for line in meshFile:
+            header_lines.append(line)
+            if line.strip().startswith('@1'):
+                break
+
+        # Parse header info
+        for line in header_lines:
+            line = line.strip()
+            if not line:
+                continue
+            if 'define' in line and 'Lattice' in line:
+                dims = list(map(int, line.split()[-3:]))
+                extent = [v for dim in dims for v in (0, dim - 1)]
+            elif 'BoundingBox' in line:
+                bounds = list(map(float, line.strip(' \t\n,').split()[-6:]))
+                origin = [bounds[2 * i] for i in range(3)]
+            elif 'Spacing' in line:
+                spacing = list(map(float, line.strip(' \t\n,').split()[-3:]))
+
+        # Adjust bounds/origin before reading the data section
+        for i in range(3):
+            bounds[2 * i + 1] += 0.5 * spacing[i]
+            bounds[2 * i] -= 0.5 * spacing[i]
+            origin[i] -= 0.5 * spacing[i]
+
+        # Read the remainder of the file as one string and convert to float64
+        data_str = meshFile.read()
+        data = np.fromstring(data_str, sep=' ', dtype=dtype)
+
+        # Reshape into a 3D array in Fortran order
+        mesh = data.reshape(dims, order='F')
+
+        return scalar_field.ScalarField(mesh, origin, extent, spacing, bounds)
+
+
+def read_scalar_field_legacy(fname=''):
     """Read AMIRA scalar fields.
     
     Args:
@@ -233,6 +295,11 @@ def read_scalar_field(fname=''):
 
     Returns:
         :py:class:`~singlecell_input_mapper.singlecell_input_mapper.scalar_field.ScalarField`: A scalar field object.
+
+    .. deprecated:: 0.5.0
+       This has been deprecated in favor of the faster :py:meth:`read_scalar_field`
+
+    :skip-doc:
     """
     if not fname.endswith('.am') and not fname.endswith('.AM'):
         raise IOError('Input file is not an Amira Mesh file!')

--- a/singlecell_input_mapper/singlecell_input_mapper/reader.py
+++ b/singlecell_input_mapper/singlecell_input_mapper/reader.py
@@ -85,7 +85,7 @@ def read_hoc_file(fname=''):
         raise IOError('Input file is not a .hoc file!')
 
     with dbopen(fname, 'r') as neuronFile:
-        logger.info("Reading hoc file", fname)
+        logger.info("Reading hoc file: {}".format(fname))
         # cell = co.Cell()
         # simply store list of edges
         # cell is parsed in CellParser

--- a/singlecell_input_mapper/singlecell_input_mapper/scalar_field.py
+++ b/singlecell_input_mapper/singlecell_input_mapper/scalar_field.py
@@ -89,38 +89,64 @@ class ScalarField(object):
         # if self.mesh is not None:
         #     self.resize_mesh()
 
-    def resize_mesh(self):
-        '''Resizes mesh to non-zero scalar data.
+    # def resize_mesh(self):
+    #     '''Resizes mesh to non-zero scalar data.
          
-        This method resizes the mesh such that the bounding box 
-        wraps around voxels that contain non-zero scalar data.
-        Also updates :py:attr:`extent` and :py:attr:`boundingBox`
-        '''
-        roi = np.nonzero(self.mesh)
-        iMin = np.min(roi[0])
-        iMax = np.max(roi[0])
-        jMin = np.min(roi[1])
-        jMax = np.max(roi[1])
-        kMin = np.min(roi[2])
-        kMax = np.max(roi[2])
-        self.extent = 0, iMax - iMin, 0, jMax - jMin, 0, kMax - kMin
-        newDims = self.extent[1] + 1, self.extent[3] + 1, self.extent[5] + 1
-        dx = self.spacing[0]
-        dy = self.spacing[1]
-        dz = self.spacing[2]
-        xMin = self.origin[0] + iMin * dx
-        yMin = self.origin[1] + jMin * dy
-        zMin = self.origin[2] + kMin * dz
-        xMax = self.origin[0] + (iMax + 1) * dx
-        yMax = self.origin[1] + (jMax + 1) * dy
-        zMax = self.origin[2] + (kMax + 1) * dz
-        self.origin = xMin, yMin, zMin
-        self.boundingBox = xMin, xMax, yMin, yMax, zMin, zMax
-        newMesh = np.empty(shape=newDims)
-        newMesh[:, :, :] = self.mesh[iMin:iMax + 1, jMin:jMax + 1,
-                                     kMin:kMax + 1]
-        self.mesh = np.copy(newMesh)
-        del newMesh
+    #     This method resizes the mesh such that the bounding box 
+    #     wraps around voxels that contain non-zero scalar data.
+    #     Also updates :py:attr:`extent` and :py:attr:`boundingBox`
+    #     '''
+    #     roi = np.nonzero(self.mesh)
+    #     iMin = np.min(roi[0])
+    #     iMax = np.max(roi[0])
+    #     jMin = np.min(roi[1])
+    #     jMax = np.max(roi[1])
+    #     kMin = np.min(roi[2])
+    #     kMax = np.max(roi[2])
+    #     self.extent = 0, iMax - iMin, 0, jMax - jMin, 0, kMax - kMin
+    #     newDims = self.extent[1] + 1, self.extent[3] + 1, self.extent[5] + 1
+    #     dx = self.spacing[0]
+    #     dy = self.spacing[1]
+    #     dz = self.spacing[2]
+    #     xMin = self.origin[0] + iMin * dx
+    #     yMin = self.origin[1] + jMin * dy
+    #     zMin = self.origin[2] + kMin * dz
+    #     xMax = self.origin[0] + (iMax + 1) * dx
+    #     yMax = self.origin[1] + (jMax + 1) * dy
+    #     zMax = self.origin[2] + (kMax + 1) * dz
+    #     self.origin = xMin, yMin, zMin
+    #     self.boundingBox = xMin, xMax, yMin, yMax, zMin, zMax
+    #     newMesh = np.empty(shape=newDims)
+    #     newMesh[:, :, :] = self.mesh[iMin:iMax + 1, jMin:jMax + 1,
+    #                                  kMin:kMax + 1]
+    #     self.mesh = np.copy(newMesh)
+    #     del newMesh
+
+    def resize_mesh(self):
+        """Resizes mesh to non-zero scalar data using slicing views (no copy)."""
+        roi = np.where(self.mesh)
+        if roi[0].size == 0:
+            return  # no non-zero voxels
+
+        iMin, iMax = roi[0].min(), roi[0].max()
+        jMin, jMax = roi[1].min(), roi[1].max()
+        kMin, kMax = roi[2].min(), roi[2].max()
+
+        self.extent = (0, iMax - iMin, 0, jMax - jMin, 0, kMax - kMin)
+
+        dx, dy, dz = self.spacing
+        xMin, yMin, zMin = (self.origin[0] + iMin * dx,
+                            self.origin[1] + jMin * dy,
+                            self.origin[2] + kMin * dz)
+        xMax, yMax, zMax = (self.origin[0] + (iMax + 1) * dx,
+                            self.origin[1] + (jMax + 1) * dy,
+                            self.origin[2] + (kMax + 1) * dz)
+
+        self.origin = (xMin, yMin, zMin)
+        self.boundingBox = (xMin, xMax, yMin, yMax, zMin, zMax)
+
+        # Slice view instead of copying
+        self.mesh = self.mesh[iMin:iMax + 1, jMin:jMax + 1, kMin:kMax + 1]
 
     def get_scalar(self, xyz):
         '''Fetch the scalar value of the voxel containing the point xyz.
@@ -195,6 +221,31 @@ class ScalarField(object):
         j = int((y - self.origin[1]) // self.spacing[1])
         k = int((z - self.origin[2]) // self.spacing[2])
         return i, j, k
+
+    def get_mesh_coordinates_vectorized(self, coords):
+        """
+        Vectorized sampling of scalar values at multiple coordinates.
+        coords: ndarray (..., 3) of (x,y,z)
+        Returns: ndarray of scalar values (same shape as coords[..., 0])
+        """
+        # Convert world coordinates (x,y,z) into voxel indices (i,j,k)
+        x_idx = ((coords[..., 0] - self.origin[0]) // self.spacing[0]).astype(int)
+        y_idx = ((coords[..., 1] - self.origin[1]) // self.spacing[1]).astype(int)
+        z_idx = ((coords[..., 2] - self.origin[2]) // self.spacing[2]).astype(int)
+
+        # Check which points are inside the mesh bounds
+        valid = (
+            (x_idx >= 0) & (x_idx < self.mesh.shape[0]) &
+            (y_idx >= 0) & (y_idx < self.mesh.shape[1]) &
+            (z_idx >= 0) & (z_idx < self.mesh.shape[2])
+        )
+
+        # Initialize result array with zeros
+        result = np.zeros(coords.shape[:-1], dtype=self.mesh.dtype)
+
+        # Only sample valid points
+        result[valid] = self.mesh[x_idx[valid], y_idx[valid], z_idx[valid]]
+        return result
 
     def get_voxel_bounds(self, ijk):
         '''Gets the bounding box of voxel given by indices i,j,k. 

--- a/singlecell_input_mapper/singlecell_input_mapper/synapse_mapper.py
+++ b/singlecell_input_mapper/singlecell_input_mapper/synapse_mapper.py
@@ -279,6 +279,63 @@ class SynapseDensity(object):
         self.inhPST = inhPST
         self.cellPST = {}
 
+    def compute_synapse_density_vectorized(self, boutonDensity, preCellType):
+        """Vectorized version of synapse density computation."""
+        if not self.cellPST:
+            self.compute_cell_PST()
+
+        if preCellType in self.exTypes:
+            normPSTDensity = self.exPST
+            cellPSTDensity = self.cellPST['EXC']
+        elif preCellType in self.inhTypes:
+            normPSTDensity = self.inhPST
+            cellPSTDensity = self.cellPST['INH']
+        else:
+            raise RuntimeError(f"Invalid presynaptic cell type: {preCellType}")
+
+        synapseDensity = {}
+        for anatomical_area, pstField in cellPSTDensity.items():
+            # Check bounding box overlap
+            if not self._intersect_bboxes(boutonDensity.boundingBox, pstField.boundingBox):
+                return None
+
+            # Pre-allocate synapse field
+            synapseField = ScalarField(
+                np.zeros_like(pstField.mesh),
+                pstField.origin,
+                pstField.extent,
+                pstField.spacing,
+                pstField.boundingBox
+            )
+            synapseDensity[anatomical_area] = synapseField
+
+            # Precompute voxel centers in a vectorized way
+            shape = pstField.mesh.shape
+            dx, dy, dz = pstField.spacing
+            x = pstField.origin[0] + (np.arange(shape[0]) + 0.5) * dx
+            y = pstField.origin[1] + (np.arange(shape[1]) + 0.5) * dy
+            z = pstField.origin[2] + (np.arange(shape[2]) + 0.5) * dz
+
+            X, Y, Z = np.meshgrid(x, y, z, indexing='ij')
+            coords = np.stack([X, Y, Z], axis=-1)
+
+            # Vectorized bouton and normPST sampling
+            boutons = boutonDensity.get_mesh_coordinates_vectorized(coords)
+            normPST = normPSTDensity.get_mesh_coordinates_vectorized(coords)
+
+            # Vectorized computation: mask out invalid values
+            valid_mask = (boutons > 0) & (normPST > 0)
+            synapseField.mesh[valid_mask] = (
+                boutons[valid_mask] * pstField.mesh[valid_mask] / normPST[valid_mask]
+            )
+
+        # Remove empty density fields
+        synapseDensity = {
+            area: field for area, field in synapseDensity.items()
+            # if np.any(field.mesh > 0)  # keep key, even if mesh is empty (for backwards compatibility)
+        }
+        return synapseDensity if synapseDensity else None
+
     def compute_synapse_density(self, boutonDensity, preCellType):
         '''Compute the density of synapses of a given presynaptic celltype onto the postsynaptic neuron.
         

--- a/singlecell_input_mapper/singlecell_input_mapper/synapse_mapper.py
+++ b/singlecell_input_mapper/singlecell_input_mapper/synapse_mapper.py
@@ -555,9 +555,7 @@ class SynapseDensity(object):
         logger.info('---------------------------')
         totalLength = 0.0
         for structure in list(lengthDensity.keys()):
-            logger.info(
-                'Computing 3D length/surface area density of structures with label {:s}'
-                .format(structure))
+            logger.debug('Computing 3D length/surface area density of structures with label {:s}'.format(structure))
             density1 = lengthDensity[structure]
             density2 = surfaceAreaDensity[structure]
             #===================================================================
@@ -675,8 +673,7 @@ class SynapseDensity(object):
                             density1.mesh[ijk] += length
                             density2.mesh[ijk] += area
                             totalLength += length
-        logger.info('Total clipped length = {:f}'.format(totalLength))
-        logger.info('---------------------------')
+        logger.debug('Total clipped length = {:f}'.format(totalLength))
 
     def _clip_u(self, pq, u1u2):
         '''Liang-Barsky clipping algorithm :cite:`liang1984new` for line segments in 3D.


### PR DESCRIPTION
Performance improvements in three places that take up a decent amount of time during network mapping. Speedup for the entire pipeline is roughly between 450% and 800%

Future speedup can in principle be achieved by parallellizing synapse density computation for different cell types and/or columns.

## 1. Reading mesh files
The AMIRA mesh readers in `single_cell_parser/reader.py` and `singlecell_input_mapper/singlecell_input_mapper/reader.py` 
Reading in AMIRA mesh files is no longer line by line, but will read until it hits the `@1` header and then convert the remaining content (i.e. the actual scalar data) to a numpy matrix in one pass using `numpy.fromstring()`. Previously, this data was added to a nested list with by indexing a nested list each iteration of reading a line, which is computationally expensive.

The old reader function is kept under the name `read_scalar_field_legacy`

Speedup $\approx \times 4.26 \pm 0.21$

## 2. Resizing meshes 

The `ScalarField` classes in `single_cell_parser/scalar_field.py` and `singlecell_input_mapper/singlecell_input_mapper/scalar_field.py` made a copy of the original mesh at the end for no good reason. This is updated to use a slice view instead. In addition to the speedup, this is also less memory hungry :)

Old method is commented out, but kept

Speedup $\approx \times 2$

## 3. Computing synapse densities

This is the gist of the network mapping procedure. These synapse densities are calculated for each cell type, for each column (or "anatomical area"). Previously, these were calculated separately for each voxel by indiviudally iterating these voxels. This is now vectorized across voxels.

The original synapse density computation is simply kept as-is. however, the default behavior of calling the top-level `map_singlecell_inputs` uses the vectorized version.

Speedup $\approx \times 20$

# Compatibility test

To test whether these new implementations do in fact produce the same result, I compared the resulting `.syn` and `.con` files from the original implementation to two individual runs of the new implementation (using the same `numpy.random.seed`). The results are _exactly_ the same. I had to specify mesh reading to use `numpy.float64` instead of `numpy.float32` to get exactly identical results (as this is the default Python `dtype` that was used when simply reading line by line). This `dtype` can be specified in a `kwarg` though.

|           | Time     | Speedup |
|-----------|----------|---------|
| Original  | 29.1 min |         |
| New run 1 | 6.4 min  | x4.5    |
| New run 2 | 3.6 min  | x8      |