### PR TITLE
Fix `synaptic_strength_fitting` test

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -124,7 +124,7 @@ default = ["isf"]
 # -------------------------------------------------------------------------
 [tool.pytest.ini_options]
 markers = [
-  "heavy: Mark a test as heavy. This ensures it is scheduled early in the test suite.",
+  "early: Mark a test as early, ensuring it is scheduled early in the test suite.",
   "statistical(n_runs, max_failure_rate): Mark tests to rerun multiple times to determine statistical significance."
 ]
 # Don't schedule new tests if the previous exceeded this time

--- a/simrun/synaptic_strength_fitting.py
+++ b/simrun/synaptic_strength_fitting.py
@@ -246,7 +246,7 @@ class PSPs:
             out[cell_type][g1][g2] = self.result[n]
             # calculate maximum voltage in the respective simulation
             # list comprehension used to flatten the list
-            max = np.max([x for x in self.result[n][3] for x in x])
+            # max = np.max([x for x in self.result[n][3] for x in x])
             #if  max > -45:
             #    errstr = "Result Nr {} has a maximum membrane potential of {} mV. ".format(lv, max) +\
             #             "Make sure, the cell does not depolarize during initialization "+\

--- a/simrun/synaptic_strength_fitting.py
+++ b/simrun/synaptic_strength_fitting.py
@@ -613,7 +613,7 @@ def run_ex_synapse(
     synapseID=None,
     tEnd=None,
     tStim=None):
-    '''Simulate a single excitatory or inhibitory synapse
+    '''Simulate a single excitatory or inhibitory synapse.
     
     This is the core function to activate a single synapse and run the simulation.
     Used in the :py:class:`~simrun.synaptic_strength_fitting.PSPs` class to simulate each synapse.
@@ -717,6 +717,9 @@ def run_ex_synapses(
     tEnd=None,
     mode='cells'):
     '''Simulate all EPSPs of a given celltype, one by one.
+
+    This function reads the network parameter file, selects one celltype, and activates each synapse of that celltype,
+    as defined by their corresponding :ref:`syn_file_format` file. The simulation is reset after each synapse activation run.
     
     This function is used in the :py:class:`~simrun.synaptic_strength_fitting.PSPs` class to simulate each synapse.
     

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -51,17 +51,17 @@ def pytest_collection_modifyitems(session, config, items):
     Currently, heavy tests are simply scheduled first.
     This may be extended in the future.
     """
-    heavy = []
+    early = []
     normal = []
 
     for item in items:
-        if 'heavy' in item.keywords:
-            heavy.append(item)
+        if 'early' in item.keywords:
+            early.append(item)
         else:
             normal.append(item)
 
     # Place heavy tests at the beginning
-    items[:] = heavy + normal
+    items[:] = early + normal
 
 
 def pytest_ignore_collect(collection_path, config):

--- a/tests/fixtures/dask_fixtures.py
+++ b/tests/fixtures/dask_fixtures.py
@@ -30,11 +30,12 @@ def dask_cluster(pytestconfig):
 
 
 @pytest.fixture(scope="function")
-def client(dask_cluster, pytestconfig):
-    n_workers = int(pytestconfig.getini("DASK_N_WORKERS")) or 2
+def client(dask_cluster, pytestconfig, n_workers=None):
+    """Function-scoped Dask client for executing tasks."""
+    default_n_workers = int(pytestconfig.getini("DASK_N_WORKERS"))
+    n_workers = n_workers or default_n_workers
     client = Client(dask_cluster)
     client.wait_for_workers(n_workers)
     
     yield client
-    # logs = client.get_worker_logs()
     client.close()

--- a/tests/test_simrun/synaptic_strength_fitting_test.py
+++ b/tests/test_simrun/synaptic_strength_fitting_test.py
@@ -23,6 +23,7 @@ PSPs = simrun.synaptic_strength_fitting.PSPs
 
 
 #@decorators.testlevel(2)
+@pytest.mark.early
 @pytest.mark.skipif(not BC_MODEL_AVAILABLE, reason="Barrel cortex model not available, but synaptic strength values are BC-specific")
 def test_VPM_synaptic_strength_is_between_1_72_and_1_85(client):
     """

--- a/tests/test_simrun/synaptic_strength_fitting_test.py
+++ b/tests/test_simrun/synaptic_strength_fitting_test.py
@@ -23,8 +23,8 @@ PSPs = simrun.synaptic_strength_fitting.PSPs
 
 
 #@decorators.testlevel(2)
-@pytest.mark.early
 @pytest.mark.skipif(not BC_MODEL_AVAILABLE, reason="Barrel cortex model not available, but synaptic strength values are BC-specific")
+@pytest.mark.parametrize("n_workers", [6])  # increase number of workers to speed up the test
 def test_VPM_synaptic_strength_is_between_1_72_and_1_85(client):
     """
     Limits are educated guesses, but it should never deviate by a lot.

--- a/tests/test_simrun/synaptic_strength_fitting_test.py
+++ b/tests/test_simrun/synaptic_strength_fitting_test.py
@@ -24,7 +24,7 @@ PSPs = simrun.synaptic_strength_fitting.PSPs
 
 #@decorators.testlevel(2)
 @pytest.mark.skipif(not BC_MODEL_AVAILABLE, reason="Barrel cortex model not available, but synaptic strength values are BC-specific")
-@pytest.mark.parametrize("n_workers", [6])  # increase number of workers to speed up the test
+@pytest.mark.timeout(300)  # allow this test to run longer than default timeout
 def test_VPM_synaptic_strength_is_between_1_72_and_1_85(client):
     """
     Limits are educated guesses, but it should never deviate by a lot.


### PR DESCRIPTION
`simrun.synaptic_strength_fitting` gets really close the timeout limit of `3min` per test.

Options here are:

1. increase the timeout limit globally
2. allow tests to request a larger timeout limit
3. make the test faster

I'm going with option 2, which is a simple `@pytest.mark.timeout()`