### PR TITLE
Bugfix db paramfiles

### DIFF
--- a/data_base/db_initializers/load_simrun_general/__init__.py
+++ b/data_base/db_initializers/load_simrun_general/__init__.py
@@ -43,6 +43,45 @@ the following keys:
     * - ``spike_times``
       - Dask dataframe containing the spike times of the postsynaptic cell for all trials.
 
+      
+If you intialize the database with ``rewrite_in_optimized_format=True`` (default), the keys are written as dask dataframes to whichever format is configured as the optimized format (see :py:mod:`~data_base.isf_data_base.db_initializers.load_simrun_general.config`).
+If ``rewrite_in_optimized_format=False`` instead, these keys are pickled dask dataframes, containing the instructions to build the dataframe, not the data itself.
+This is useful for fast intermediate analysis, but strongly discouraged for long term storage, since these instructions contain absolute paths to the original data files, which invalidates once they are moved or deleted.
+Individual keys can afterwards be set to permanent, self-contained and efficient dask dataframes by calling 
+:py:meth:`~data_base.db_initializers.load_simrun_general.load_simrun_general.optimize` on specific database
+keys.
+
+Example::
+
+    >>> paramfile_copy_config = {
+    ...     "copy_method": "remount",
+    ...     "neup" : "parameterfiles_folder",
+    ...     "netp" : "parameterfiles_folder",
+    ...     "hoc" : "morphology_folder",
+    ...     "syn" : "parameterfiles_folder",
+    ...     "con" : "parameterfiles_folder",
+    ...     "recsites" : "parameterfiles_folder"
+    ... }
+    >>> simresult_path = '/path/to/raw/simrun/output/folder'
+    >>> db = I.DataBase("db_parsed_data")
+    >>> client = distributed.Client("localhost:8786")
+    >>> I.db_init_simrun_general.init(
+    ... db = db,
+    ... simresult_path = p,
+    ... core = True, 
+    ... repartition = 500,
+    ... parameterfiles = True,
+    ... synapse_activation = True, 
+    ... n_chunks = 5000,
+    ... dendritic_voltage_traces = True,
+    ... spike_times = True, 
+    ... dendritic_spike_times = False,
+    ... rewrite_in_optimized_format = True,
+    ... client = client,
+    ... check_health = True,
+    ... paramfile_copy_config = paramfile_copy_config
+    ... )
+
 After initialization, you can access the data from the data_base in the following manner::
 
     >>> db['synapse_activation']
@@ -53,13 +92,6 @@ After initialization, you can access the data from the data_base in the followin
     <voltage traces dataframe>
     >>> db['spike_times']
     <spike times dataframe>
-    
-If you intialize the database with ``rewrite_in_optimized_format=True`` (default), the keys are written as dask dataframes to whichever format is configured as the optimized format (see :py:mod:`~data_base.isf_data_base.db_initializers.load_simrun_general.config`).
-If ``rewrite_in_optimized_format=False`` instead, these keys are pickled dask dataframes, containing the instructions to build the dataframe, not the data itself.
-This is useful for fast intermediate analysis, but strongly discouraged for long term storage, since these instructions contain absolute paths to the original data files, which invalidates once they are moved or deleted.
-Individual keys can afterwards be set to permanent, self-contained and efficient dask dataframes by calling 
-:py:meth:`~data_base.db_initializers.load_simrun_general.load_simrun_general.optimize` on specific database
-keys.
 
 See also:
     :ref:`simresult_dir_format` for more information on the raw output format of :py:mod:`simrun`.
@@ -122,11 +154,11 @@ def init(
     client=None,
     check_health=False,
     n_chunks=5000,
+    paramfile_copy_config=None,
     # deprecated args;
     voltage_traces=None,
     burst_times=None,
     dumper=None,
-    paramfile_copy_config=None
 ):
     """Initialize a database with simulation data.
 
@@ -172,8 +204,8 @@ def init(
     
             - ``copy_method`` (str): Which copy strategy to use. 
               Must be either ``"hash_rename"`` or ``"remount"``. 
-              ``"hash_rename"`` will rename all parameterfiles to a hash of their content. Useful when you want all parameter files in one folder and avoid fielname clashes.
-              ``"remount"`` will preserve the relative directory structure of the parameterfiles per file category (see below). Useful when parameterfiles are already organized.
+              ``"hash_rename"`` renames all parameterfiles to a hash of their content, filtering out files with identical content.
+              ``"remount"`` preserves the relative directory structure of the parameterfiles per file category.
             - "neup" (str): Target directory name of :ref:`neuron_params_format`. Default is ``"parameterfiles_folder"``
             - "netp" (str): Target directory name of :ref:`network_params_format`. Default is ``"parameterfiles_folder"``
             - "hoc" (str): Target directory name of :ref:`hoc_file_format` files. Default is ``"parameterfiles_folder"``
@@ -187,18 +219,19 @@ def init(
             Scheduler to use for parallellized parsing of dask dataframes.
             can e.g. be simply the ``distributed.Client.get`` method.
             Default is ``None``.
+
             
     Note:
         Note the difference between *amount* of partitions (:paramref:`n_chunks`) and target partition *size* (:paramref:`repartition`)
 
+    .. deprecated:: 0.2.0
+        The :paramref:`burst_times` argument is deprecated and will be removed in a future version.
+        
     .. versionadded:: 0.5.0
        The keyword argument :paramref:`repartition` now accepts integers in addition to booleans.
        Integers reflect the target size of each voltage trace dataframe partition. Booleans reflect either
        ``True`` for a default lenght, or ``False`` for no repartitioning (i.e. one ``.csv`` file per partition)
 
-    .. deprecated:: 0.2.0
-        The :paramref:`burst_times` argument is deprecated and will be removed in a future version.
-        
     .. deprecated:: 0.5.0
        The :paramref:`dumper` argument is deprecated and will be removed in a future version.
        Dumpers are configured in the centralized :py:mod:`~data_base.db_initializers.load_simrun_general.config` module.

--- a/data_base/db_initializers/load_simrun_general/builders.py
+++ b/data_base/db_initializers/load_simrun_general/builders.py
@@ -249,12 +249,12 @@ def _build_dendritic_voltage_traces(db, repartition=None):
 
     # Construct dendritic filelist from existing filelist, as built by _build_core
     # Don't reconstruct it using make_filelist() here, otherwise you would have to rerun the health check (redundant)
-    suffix = "*vm_dend_traces*"
+    suffix = "vm_dend_traces"
     path_globs = [
         os.path.join(
             db['simresult_path'],
             os.path.dirname(e),
-            suffix)
+            "*"+suffix+"*")
         for e in db['filelist']
     ]
     filelist = [

--- a/data_base/db_initializers/load_simrun_general/builders.py
+++ b/data_base/db_initializers/load_simrun_general/builders.py
@@ -332,7 +332,7 @@ def _build_param_files(db, paramfile_copy_config=None, client=None):
     db.set("parameterfiles", param_file_hash_df, dumper=pandas_to_msgpack)
 
     # Copy and parameterfiles and adapt internal references
-    fn_map = parallel_resolve_and_copy_paramfiles_to_db(
+    source_to_target_fn_maps = parallel_resolve_and_copy_paramfiles_to_db(
         paramfile_hashmap_df=param_file_hash_df,
         db=db,
         paramfile_target_dirs=paramfile_target_dirs,
@@ -341,12 +341,10 @@ def _build_param_files(db, paramfile_copy_config=None, client=None):
     )
 
     logger.info("Updating parameter file locations under `parameterfiles` key")
-    # Dev note: this takes a little time. create_reldb_path() walks up until it finds a db, which is overhead that can be avoided
-    # Dev note: and _hash_file_content() simply takes some minimal time. Maybe can be parallellized?
-    neup_hash_map = {_hash_file_content(fn): v for fn, v in fn_map['neup'].items()}
-    netp_hash_map = {_hash_file_content(fn): v for fn, v in fn_map['netp'].items()}
-    param_file_hash_df['path_neuron'] = param_file_hash_df['hash_neuron'].apply(neup_hash_map.get).apply(create_reldb_path)
-    param_file_hash_df['path_network'] = param_file_hash_df['hash_network'].apply(netp_hash_map.get).apply(create_reldb_path)
+    # Bjorge: this takes a little time. create_reldb_path() walks up until it finds a db, which is overhead that can be avoided
+    # Bjorge: and _hash_file_content() simply takes some minimal time. Maybe can be parallellized?
+    param_file_hash_df['path_neuron'] = param_file_hash_df['path_neuron'].apply(source_to_target_fn_maps['neup'].get).apply(create_reldb_path)
+    param_file_hash_df['path_network'] = param_file_hash_df['path_network'].apply(source_to_target_fn_maps['netp'].get).apply(create_reldb_path)
     db.set("parameterfiles", param_file_hash_df)
 
 

--- a/data_base/db_initializers/load_simrun_general/builders.py
+++ b/data_base/db_initializers/load_simrun_general/builders.py
@@ -258,9 +258,13 @@ def _build_dendritic_voltage_traces(db, repartition=None):
         for e in db['filelist']
     ]
     filelist = [
-        path_glob_match 
+        path_glob_match
         for path_glob in path_globs 
         for path_glob_match in glob.glob(path_glob)
+    ]
+    relative_filelist = [
+        os.path.relpath(f, db['simresult_path'])
+        for f in filelist
     ]
 
     recsite_labels = get_recsite_labels_from_dend_vt_filelist(filelist, full_suffix=suffix)
@@ -270,7 +274,7 @@ def _build_dendritic_voltage_traces(db, repartition=None):
     divisions = db["voltage_traces"].divisions 
     dend_vt_per_recsite_label = load_dendritic_voltage_traces(
         db, 
-        filelist, 
+        relative_filelist, 
         recsite_labels, 
         repartition=repartition, 
         divisions=divisions)

--- a/data_base/db_initializers/load_simrun_general/file_handling.py
+++ b/data_base/db_initializers/load_simrun_general/file_handling.py
@@ -133,25 +133,28 @@ def get_recsite_labels_from_dend_vt_filelist(filelist, full_suffix):
     Returns:
         List[str]: List of recording site labels.
     """
-    simresult_dirs, fns = zip(*[
-        (
-            os.path.basename(os.path.dirname(e)), 
-            os.path.basename(e)
-        ) 
-        for e in filelist])
-    #    old naming convention: subdirectory/20250101-1553_0001
-    #  newer naming convention: subdirectory/20250101-1553_seed0001
-    # newest naming convention: subdirectoy/20250101-1553_seed123456_pid0001
-    prefixes_no_date = ["_".join(e.split("_")[1:]) for e in simresult_dirs]
+    # simresult_dirs, fns = zip(*[
+    #     (
+    #         os.path.basename(os.path.dirname(e)), 
+    #         os.path.basename(e)
+    #     ) 
+    #     for e in filelist])
+    #    old naming convention: subdirectory/20250101-1553_0001/*
+    #  newer naming convention: subdirectory/20250101-1553_seed0001/*
+    # newest naming convention: subdirectoy/20250101-1553_seed123456_pid0001/*
+    # prefixes_no_date = ["_".join(e.split("_")[1:]) for e in simresult_dirs]
     
     # example file:
     # seed2622647967_pid162918_pos_1_ID_000_sec_073_seg_000_x_0.056_somaDist_581.6_vm_dend_traces.csv
     # ------- prefix -------- _----------------- recsite label ------------------ _------ suffix ----
+    # recsite_labels = [
+    #         e[len(prefix)+1:-len(full_suffix)-1] 
+    #         for e, prefix in zip(fns, prefixes_no_date)
+    #         ]
 
-    recsite_labels = [
-        e[len(prefix)+1:-len(full_suffix)-1] 
-        for e, prefix in zip(fns, prefixes_no_date)
-        ]
+    basenames = [os.path.basename(e) for e in filelist]
+    pattern = re.compile(r"(seed\d+)?_?(pid\d+)?_?(?P<recsite_label>[a-zA-Z0-9\._]+)(?=_).*" + re.escape(full_suffix))
+    recsite_labels = [re.match(pattern, e).group("recsite_label") for e in basenames]
     return recsite_labels
 
     
@@ -176,5 +179,5 @@ def _get_recsite_ids_from_recsite_labels(recsite_labels):
     try:
         ids = [pattern.search(e).group("number") for e in recsite_labels]
     except AttributeError as e:
-        raise ValueError("Found recsite IDs that don't contain the substring ID_[digits]") from e
+        raise ValueError("Found recsite IDs that don't contain the substring ID_[digits]: {}".format(recsite_labels)) from e
     return ids

--- a/data_base/db_initializers/load_simrun_general/filepath_resolution.py
+++ b/data_base/db_initializers/load_simrun_general/filepath_resolution.py
@@ -5,9 +5,10 @@ import re
 from data_base.dbopen import (
     create_modular_db_path,
     create_reldb_path,
+    _find_parent_db,
+    resolve_db_path,
 )
 from data_base.exceptions import DataBaseException
-
 logger = logging.getLogger("ISF").getChild(__name__)
 
 
@@ -139,14 +140,9 @@ def _convert_con_fns_to_reldb(con_content, syn_fn_map, con_fn):
         target_syn_file = list(syn_fn_map.values())[0]
     else:
         if not os.path.isabs(matches[0]):
-            dir_path = os.path.dirname(con_fn)
-            matches[0] = os.path.join(dir_path, matches[0])
-            assert os.path.exists(
-                matches[0]
-            ), "The .syn file referenced in the .con file was not found:\n{}".format(
-                matches[0]
-            )
-        target_syn_file = syn_fn_map[matches[0]]
+            abs_fn = _resolve_syncon_ref(con_fn, matches[0])
+        else: abs_fn = matches[0]
+        target_syn_file = syn_fn_map[abs_fn]
 
     relative_syn_file = create_reldb_path(target_syn_file)
     con_content[1] = "# {}\n".format(relative_syn_file)
@@ -169,3 +165,34 @@ def _create_db_path_print(path, replace_dict=None):
     except DataBaseException as e:
         # print e
         return path, False
+
+
+def _resolve_rel_syncon_ref(fn, ref):
+    """Resolve a relative database style path of .syn or .con files
+
+    Args:
+        fn (str): The filename containing the reference
+        ref (str): The relative reference to a .syn or .con file.
+
+    Returns:
+        str: The absolute path to the referenced file.
+    """
+    assert ref.startswith("reldb://")
+    db_basedir = _find_parent_db(fn)
+    abs_ref = resolve_db_path(ref, db_basedir=db_basedir)
+    return abs_ref
+
+def _resolve_syncon_ref(fn, ref):
+    """Resolve relative references in :ref:`syn_file_format` or :ref:`conf_file_format` files.
+
+    Relative references can either be filenmaes without preceding directory structure, or reldb://-style relative paths.
+    """
+    if ref.startswith("reldb://"): 
+        abs_fn = _resolve_rel_syncon_ref(fn, ref)
+    else:
+        dir_path = os.path.dirname(fn)
+        abs_fn = os.path.join(dir_path, ref)
+    assert os.path.exists(
+        abs_fn
+    ), "The .syn file referenced in the .con file was not found:\n{}".format(abs_fn)
+    return abs_fn

--- a/data_base/db_initializers/load_simrun_general/param_file_parser.py
+++ b/data_base/db_initializers/load_simrun_general/param_file_parser.py
@@ -61,7 +61,7 @@ def construct_param_filename_hashmap_df(simresult_path, sim_trial_index):
 
 
     """
-    logging.info("find unique parameterfiles")
+    logging.info("Mapping sim_trial_index to parameter files...")
 
     def get_simrun_dir_and_pid(row):
         sim_result_dir = os.path.dirname(row.sim_trial_index)
@@ -307,6 +307,7 @@ def _generate_target_filenames(db, db_target_dir, filelist, copy_method="remount
 def _extract_unique_references_from_neup_and_netp(
     paramfile_hashmap_df,
     client=None,
+    filter_param_files_by_content=False,
 ):
     """
     Extract all unique references to :ref:`syn_file_format` and :ref:`con_file_format` files from :ref:`network_parameters_format`,
@@ -317,21 +318,26 @@ def _extract_unique_references_from_neup_and_netp(
             A pandas dataframe containing all :ref:`neuron_parameters_format` and :ref:`network_parameters_format`,
             as well as a hash of their content.
             Should normally be created by :py:meth:`construct_param_filename_hashmap_df`
+        filter_param_files_by_content (bool): Whether to filter out parameter files with identical content
         client (:py:class:`distributed.client.Client`):
             A parallellization client. 
    
     Returns:
         Dict[str, List]: A dictionary mapping each filetype (str) to a list of unique references of that filetype. 
     """
-    
     neup_path_column="path_neuron"
     neup_hash_column="hash_neuron" 
     netp_path_column="path_network"
     netp_hash_column="hash_network"
 
-    # Get unique parameter files
-    cell_param_fns = paramfile_hashmap_df.drop_duplicates(subset=neup_hash_column)[neup_path_column].tolist()
-    netp_param_fns = paramfile_hashmap_df.drop_duplicates(subset=netp_hash_column)[netp_path_column].tolist()
+    # Get unique parameter files, unique meaning unique content
+    if filter_param_files_by_content == True:
+        cell_param_fns = paramfile_hashmap_df.drop_duplicates(subset=neup_hash_column)[neup_path_column].tolist()
+        netp_param_fns = paramfile_hashmap_df.drop_duplicates(subset=netp_hash_column)[netp_path_column].tolist()
+    # Get unique parameter files, unique meaning unique filepath
+    else:
+        cell_param_fns = paramfile_hashmap_df[neup_path_column].tolist()
+        netp_param_fns = paramfile_hashmap_df[netp_path_column].tolist()
     
     logger.info(f"{len(netp_param_fns)} unique network parameter files")
     logger.info(f"{len(cell_param_fns)} unique neuron parameter files")
@@ -488,10 +494,11 @@ def parallel_resolve_and_copy_paramfiles_to_db(
         dict: The filename map for each file type.
     """
     
-    # Phase 1: Extract all unique files
+    # Phase 1: Extract all unique files from parameter files
     source_file_list = _extract_unique_references_from_neup_and_netp(
         paramfile_hashmap_df=paramfile_hashmap_df,
         client=client,
+        filter_param_files_by_content=True if copy_method == "hash_rename" else False
     )
 
     # Create filename map and scatter to cluster

--- a/data_base/db_initializers/load_simrun_general/param_file_parser.py
+++ b/data_base/db_initializers/load_simrun_general/param_file_parser.py
@@ -291,6 +291,7 @@ def _generate_target_filenames(db, db_target_dir, filelist, copy_method="remount
         # New param file name will be the content hash
         new_base_fns = client.gather(client.map(_hash_file_content, filelist))
     elif copy_method == "remount":
+        assert len(filelist) > 1, "Can't preserve folder structure with only a single file. If you want to do this, please use copy_method='hash_rename'. Filelist: {}".format(filelist)
         # paramfiles are copied over in the same folder structure.
         base_fn = os.path.commonpath(filelist)
         # Not worth parallellizing for now, it's fast enough. Overhead of sending to client may be slower than this

--- a/data_base/db_initializers/load_simrun_general/param_file_parser.py
+++ b/data_base/db_initializers/load_simrun_general/param_file_parser.py
@@ -291,11 +291,11 @@ def _generate_target_filenames(db, db_target_dir, filelist, copy_method="remount
         # New param file name will be the content hash
         new_base_fns = client.gather(client.map(_hash_file_content, filelist))
     elif copy_method == "remount":
-        assert len(filelist) > 1, "Can't preserve folder structure with only a single file. If you want to do this, please use copy_method='hash_rename'. Filelist: {}".format(filelist)
+        assert len(filelist) > 1, "Can't calculate the relative directory structure from a single file, so copy_method='remount' can't be used here. Consider using copy_method='hash_rename' instead. Filelist: {}".format(filelist)
         # paramfiles are copied over in the same folder structure.
         base_fn = os.path.commonpath(filelist)
         # Not worth parallellizing for now, it's fast enough. Overhead of sending to client may be slower than this
-        new_base_fns = [os.path.relpath(e, start=base_fn) for e in filelist]    
+        new_base_fns = [os.path.relpath(e, start=base_fn) for e in filelist]
     else:
         raise ValueError("Config value PARAM_FILE_COPY_METHOD={} is not supported. SUpported values are hash_rename or remount.")
     new_fns = [

--- a/data_base/db_initializers/load_simrun_general/param_file_parser.py
+++ b/data_base/db_initializers/load_simrun_general/param_file_parser.py
@@ -177,7 +177,7 @@ def _resolve_and_copy_neuron_param(neup_fn, scattered_fn_map):
     try:
         neup.save(target_fn)
     except FileNotFoundError:
-        os.makedirs(os.path.dirname(target_fn))
+        os.makedirs(os.path.dirname(target_fn), exist_ok=True)
         neup.save(target_fn)
 
 
@@ -205,7 +205,7 @@ def _resolve_and_copy_network_param(netp_fn, scattered_fn_map):
     try:
         netp.save(target_fn)
     except FileNotFoundError:
-        os.makedirs(os.path.dirname(target_fn))
+        os.makedirs(os.path.dirname(target_fn), exist_ok=True)
         netp.save(target_fn)
 
 
@@ -281,7 +281,11 @@ def _generate_target_filenames(db, db_target_dir, filelist, copy_method="remount
             These directories will be a :py:class:`data_base.isf_data_base.ManagedFolder`
         filelist (List[str]): The original file names.
         client (:py:class:`distributed.client.Client`):
-            A parallellization client. Only needed if ``"PARAMFILE_COPY_METHOD"`` is configured to ``"hash_rename"``
+            A parallellization client. Only needed if ``"PARAMFILE_COPY_METHOD"`` is configured to ``"hash_rename"``relative_filelist = [
+        os.path.relpath(path_glob_match, db['simresult_path'])
+        for path_glob in path_globs 
+        for path_glob_match in glob.glob(path_glob)
+    ]
 
     Returns:
         str: The target filename in the database.

--- a/data_base/dbopen.py
+++ b/data_base/dbopen.py
@@ -67,6 +67,17 @@ def cache(function):
     return wrapper
 
 
+def _find_parent_db(path):
+    parent_db_path = path
+    while not is_data_base(parent_db_path):
+        new_parent_db_path = os.path.dirname(parent_db_path)
+        if new_parent_db_path == parent_db_path:
+            raise DataBaseException(
+                "The path {} does not seem to be within a DataBase!".format(path))
+        parent_db_path = new_parent_db_path
+    return parent_db_path
+
+
 def resolve_reldb_path(path, db_basedir=None):
     """Resolve a relative database path
     
@@ -90,6 +101,8 @@ def resolve_reldb_path(path, db_basedir=None):
     if not path.startswith('reldb://'):
         return path
     
+    # Could use _find_parent_db here, but that may yeild bad performance if used nilly-willy
+    # it should be the responsibility of the caller to handle this function correctly - Bjorge.
     assert db_basedir is not None, "If the path is in reldb:// format, the database basedir must be provided in order to resolve it."
 
     abs_path = os.path.join(db_basedir, *path.split('/')[2:])
@@ -122,12 +135,7 @@ def create_reldb_path(path):
         logger.debug('Path {} already in reldb:// format'.format(path))
         return path
     
-    parent_db_path = path
-    while not is_data_base(parent_db_path):
-        parent_db_path = os.path.dirname(parent_db_path)
-        if parent_db_path == '/':
-            raise DataBaseException(
-                "The path {} does not seem to be within a DataBase!".format(path))
+    parent_db_path = _find_parent_db(path)
 
     relpath = os.path.relpath(path, parent_db_path)
     return os.path.join('reldb://', relpath)
@@ -190,22 +198,12 @@ def create_modular_db_path(path):
     Returns:
         str: The database path.
     """
-    db_path = path
     if path.startswith('mdb://'):
         logger.debug('Path {} already in mdb:// format'.format(path))
         return path
     
     # Find mother database
-    while True:
-        if (os.path.isdir(db_path)) and (
-            'dbcore.pickle' in os.listdir(db_path) or 'db_state.json' in os.listdir(db_path) or 'dbcore.pickle' in os.listdir(db_path)):
-            break
-        else:
-            db_path = os.path.dirname(db_path)
-        if db_path == '/':
-            raise DataBaseException(
-                "The path {} does not seem to be within a DataBase!".
-                format(path))
+    db_path = _find_parent_db(path)
     
     # Instantiate mother database
     db = DataBase(db_path, nocreate=True, readonly=True)


### PR DESCRIPTION
This PR fixes the following bugs in parsing parameterfiles into a database:
- When `copy_method="remount"`, copying parameterfiles failed when only one parameterfile of a certain kind is found. In these cases, it cannot infer the shared filestructure it is supposed to be preserving. Having only 1 paramfile easily happens when you resimulate a subselection of trials and want to initialize those in a db. The odds those all share the same .hoc file is not small
- It could not yet resolve relative references to `.syn` and `.hoc` files in `.con` and `.syn` files resp. This issue only arised when resimulating trials, where the network parameters will have references to e.g. `.con` files whose internal references have already been resolved and put in a database. 
- Fetching the recsite ID from dendritic voltage traces was not robust to different naming schemes. Now uses a regex instead of making assumptions on filename conventions
- Rerunning creation of parameterfiles could fail for netp and neup since they did not have `exist_ok=True`.
- Dendritic voltage traces had faulty `sim_trial_index` (full path instead of just the index)

Tested by:
- Initialized db from marias data: check ✔️ 
- re-run specific simulation trials from that db: check✔️ 
- Initialize the re-run simulation trials into yet another db: check ✔️  (had an issue where there was only 1 hoc file and - relative folder structure could not be preserved when copy_method="remount" , this now simply throws an error)
- Check if results are same for soma voltage traces: check ✔️ 
- Check if results are same for dendritic voltage traces: check ✔️ (found bug in sim_trial_index for that one, now fixed)