### PR TITLE
Pin down NEURON on macOS

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,9 +70,8 @@ blenderspike-py = { git = "https://github.com/ArtemKirsanov/BlenderSpike.git" }
 
 # OS specific dependencies
 [tool.pixi.target.osx]
-pypi-dependencies = { 
-  neuron = ">=8.2,<9", # >=9 compiles to c++, not c, breaking our .mod files
-  "distributed"= ">=2.30.0"}
+# >=9 compiles to c++, not c, breaking our .mod files
+pypi-dependencies = { neuron = ">=8.2,<9",   "distributed"= ">=2.30.0" }
 dependencies = { numpy = "==1.21", pytables = ">=3.7.0,<4" }
 
 [tool.pixi.target.linux]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,9 @@ blenderspike-py = { git = "https://github.com/ArtemKirsanov/BlenderSpike.git" }
 
 # OS specific dependencies
 [tool.pixi.target.osx]
-pypi-dependencies = { neuron = ">=8.2", "distributed"= ">=2.30.0"}
+pypi-dependencies = { 
+  neuron = ">=8.2,<9", # >=9 compiles to c++, not c, breaking our .mod files
+  "distributed"= ">=2.30.0"}
 dependencies = { numpy = "==1.21", pytables = ">=3.7.0,<4" }
 
 [tool.pixi.target.linux]


### PR DESCRIPTION
NEURON 9.0 and up compiles `.mod` files to C++ instead of C. This is incompatible with our `.mod` files, as they have VERBATIM blocks, which are valid C code, but not always valid C++ code.

For example, `ProbAMPANMDA2.mod` has the VERBATIM block:
```c
#include<stdlib.h>
#include<stdio.h>
#include<math.h>

double nrn_random_pick(void* r);
void* nrn_random_arg(int argpos);
```

This however overloads a previous definition from:
```c
.pixi/envs/default/lib/python3.9/site-packages/neuron/.data/include/nrnrandom.h:6:7:
note: previous declaration is here
    6 | Rand* nrn_random_arg(int);
      | ~~~~~ ^
```

Overloading functions with a different return type is OK in C, but not in C++:
```cpp
error: functions that differ only in their return type cannot be
overloaded
```

Rather than making our VERBATIM blocks C++-proof, it's easier to just keep compiling them to C