### PR TITLE
Bugfix reduced model

### DIFF
--- a/simrun/modular_reduced_model_inference/data_extractor.py
+++ b/simrun/modular_reduced_model_inference/data_extractor.py
@@ -130,7 +130,7 @@ class DataExtractor_spatiotemporalSynapseActivation(_DataExtractor):
         level = self._get_spatial_bin_level(key)
         out = []
         for single_db in db:
-            for k in single_db[key].keys():
+            for k in single_db[key].keys(recurse=True):
                 k = list(k)
                 k.pop(level)
                 out.append(tuple(k))
@@ -146,7 +146,7 @@ class DataExtractor_spatiotemporalSynapseActivation(_DataExtractor):
         key = self.key
         group = list(group)
         level = self._get_spatial_bin_level(key)
-        keys = db[key].keys()
+        keys = db[key].keys(recurse=True)
         keys = sorted(keys, key=lambda x: float(x[level].split('to')[0]))
         out = []
         for k in keys:

--- a/simrun/modular_reduced_model_inference/data_extractor.py
+++ b/simrun/modular_reduced_model_inference/data_extractor.py
@@ -177,7 +177,7 @@ class DataExtractor_spatiotemporalSynapseActivation(_DataExtractor):
                 ]
             else:
                 out = [
-                    single_db[key][k][:, self.tmax - self.width:self.tmax]
+                    single_db[key][k][:, int(self.tmax - self.width):int(self.tmax)]
                     for k in keys
                 ]
             out = numpy.dstack(out)

--- a/simrun/modular_reduced_model_inference/reduced_model.py
+++ b/simrun/modular_reduced_model_inference/reduced_model.py
@@ -436,9 +436,9 @@ class DataSplitEvaluation(object):
         runs_index = []
         
         for k, solver, x in zip(self.optimizer_results_keys, self.solvers, self.optimizer_results):
-            for split_name, xx in x.iteritems():
+            for split_name, xx in x.items():
                 split = self.splits[split_name]
-                for subsplit_name, subsplit in split.iteritems():
+                for subsplit_name, subsplit in split.items():
                     runs_index.append(k[2])
                     x_index.append(xx.x)
                     success_index.append(xx.success)

--- a/simrun/modular_reduced_model_inference/solver.py
+++ b/simrun/modular_reduced_model_inference/solver.py
@@ -85,7 +85,7 @@ class _Solver(object):
             :func:`~simrun.modular_reduced_model_inference.solver._Solver.optimize_one_split`
         """
         out = {}
-        for name, split in self.strategy.DataSplitEvaluation.splits.iteritems():
+        for name, split in self.strategy.DataSplitEvaluation.splits.items():
             x0 = self.strategy._get_x0()
             self.strategy.set_split(split['train'])
             if client:
@@ -115,7 +115,7 @@ class _Solver(object):
         """
         out = {}
         names = sorted(self.strategy.DataSplitEvaluation.splits.keys())
-        #         for name, split in self.strategy.DataSplitEvaluation.splits.iteritems():
+        #         for name, split in self.strategy.DataSplitEvaluation.splits.items():
         name = names[index]
         split = self.strategy.DataSplitEvaluation.splits[name]
         x0 = self.strategy._get_x0()

--- a/simrun/modular_reduced_model_inference/strategy.py
+++ b/simrun/modular_reduced_model_inference/strategy.py
@@ -914,6 +914,22 @@ class Strategy_spatiotemporalRaisedCosine(_Strategy):
             return 'grey'
         else:
             return None
+        
+    def get_kernel_dict(self, x, normalize = False):
+        if normalize:
+            x = convert_to_numpy(self.normalize(x))
+        dict_ = self.convert_x(x)
+        out = dict()
+        for group, (x_z, x_t) in dict_.items():
+            x_z =  convert_to_numpy(x_z)
+            x_t = convert_to_numpy(x_t)
+            if group == ('EXC',):
+                out['s_exc'] = self.RaisedCosineBasis_spatial.get_superposition(x_z)
+                out['t_exc'] = self.RaisedCosineBasis_temporal.get_superposition(x_t)
+            elif group == ('INH',):
+                out['s_inh'] = self.RaisedCosineBasis_spatial.get_superposition(x_z)
+                out['t_inh'] = self.RaisedCosineBasis_temporal.get_superposition(x_t)
+        return out
 
     def visualize(
         self,

--- a/simrun/modular_reduced_model_inference/strategy.py
+++ b/simrun/modular_reduced_model_inference/strategy.py
@@ -246,7 +246,7 @@ class _Strategy(object):
             self.get_score, 
             self.get_y)
         if setup:
-            for solver in self.solvers.values():
+            for solver in list(self.solvers.values()):
                 solver._setup()
         return self
 
@@ -337,7 +337,8 @@ class Strategy_categorizedTemporalRaisedCosine(_Strategy):
     def _setup(self):
         self.compute_basis()
         self.groups = sorted(self.base_vectors_arrays_dict.keys())
-        self.len_t, self.len_trials = self.base_vectors_arrays_dict.values()[0].shape
+        self.len_t, self.len_trials = list(self.base_vectors_arrays_dict.values(
+        ))[0].shape
         self._get_score = partial(
             self._get_score_static,
             self.base_vectors_arrays_dict)
@@ -348,7 +349,7 @@ class Strategy_categorizedTemporalRaisedCosine(_Strategy):
         stSa_dict = self.data['categorizedTemporalSa']
         base_vectors_arrays_dict = {}
 
-        for group, tSa in stSa_dict.iteritems():
+        for group, tSa in stSa_dict.items():
             len_trials, len_t = tSa.shape
             base_vector_rows = []
             for t in self.RaisedCosineBasis_temporal.compute(len_t).get():
@@ -721,7 +722,8 @@ class Strategy_spatiotemporalRaisedCosine(_Strategy):
         """
         self.compute_basis()
         self.groups = sorted(self.base_vectors_arrays_dict.keys())
-        self.len_z, self.len_t, self.len_trials = self.base_vectors_arrays_dict.values()[0].shape
+        self.len_z, self.len_t, self.len_trials = list(self.base_vectors_arrays_dict.values(
+        ))[0].shape
         self.convert_x = partial(self._convert_x_static, self.groups, self.len_z)
         self._get_score = partial(self._get_score_static, self.convert_x, self.base_vectors_arrays_dict)
 
@@ -971,7 +973,7 @@ class Strategy_temporalRaisedCosine_spatial_cutoff(_Strategy):
     def _setup(self):
         self.compute_basis()
         self.groups = sorted(self.base_vectors_arrays_dict.keys())
-        self.len_z, self.len_t, self.len_trials = self.base_vectors_arrays_dict.values()[0].shape
+        self.len_z, self.len_t, self.len_trials = list(self.base_vectors_arrays_dict.values())[0].shape
         self.convert_x = partial(self._convert_x_static, self.groups, self.len_z)
         self._get_score = partial(self._get_score_static, self.convert_x, self.base_vectors_arrays_dict)
 

--- a/simrun/modular_reduced_model_inference/strategy.py
+++ b/simrun/modular_reduced_model_inference/strategy.py
@@ -768,7 +768,7 @@ class Strategy_spatiotemporalRaisedCosine(_Strategy):
             return np.array(base_vector_array).astype('f4')
 
         base_vectors_arrays_dict = {}
-        for group, spatiotemp_SA in self.data['spatiotemporalSa'].iteritems():
+        for group, spatiotemp_SA in self.data['spatiotemporalSa'].items():
             base_vector_array = _compute_base_vector_array(spatiotemp_SA)
             base_vectors_arrays_dict[group] = make_weakref(np.array(np.array(base_vector_array).astype('f4')))
         self.base_vectors_arrays_dict = base_vectors_arrays_dict
@@ -816,7 +816,7 @@ class Strategy_spatiotemporalRaisedCosine(_Strategy):
         """
         len_groups = len(groups)
         out = {}
-        x = x.reshape(len_groups, len(x) / len_groups)
+        x = x.reshape(len_groups, int(len(x) / len_groups))
         for lv, group in enumerate(groups):
             x_z = x[lv, :len_z]
             x_t = x[lv, len_z:]
@@ -851,7 +851,7 @@ class Strategy_spatiotemporalRaisedCosine(_Strategy):
             array: The weighted net input :math:`WNI(t)` of length ``n_trials``.
         """
         outs = []
-        for group, (x_z, x_t) in convert_x(x).iteritems():
+        for group, (x_z, x_t) in convert_x(x).items():
             array = base_vectors_arrays_dict[group]  # shape: (len_z, len_t, n_trials)
             time_weighed_input = np.dot(dereference(x_t), dereference(array)).squeeze()
             spacetime_weighed_input = np.dot(dereference(x_z), dereference(time_weighed_input)).squeeze()
@@ -943,7 +943,7 @@ class Strategy_spatiotemporalRaisedCosine(_Strategy):
                 dict_ = self.convert_x(self.normalize(out.x))
             else:
                 dict_ = self.convert_x(out.x)
-            for group, (x_z, x_t) in dict_.iteritems():
+            for group, (x_z, x_t) in dict_.items():
                 c = self.get_color_by_group(group)
                 self.RaisedCosineBasis_temporal.visualize_x(
                     x_t, ax=ax_t, plot_kwargs={'c': c})
@@ -980,7 +980,7 @@ class Strategy_temporalRaisedCosine_spatial_cutoff(_Strategy):
         st = self.data['st']
         stSa_dict = self.data['spatiotemporalSa']
         base_vectors_arrays_dict = {}
-        for group, stSa in stSa_dict.iteritems():
+        for group, stSa in stSa_dict.items():
             len_trials, len_t, len_z = stSa.shape
             base_vector_array = []
             for z in self.RaisedCosineBasis_spatial.compute(len_z).get():
@@ -1010,7 +1010,7 @@ class Strategy_temporalRaisedCosine_spatial_cutoff(_Strategy):
     @staticmethod
     def _get_score_static(convert_x, base_vectors_arrays_dict, x):
         outs = []
-        for group, (x_z, x_t) in convert_x(x).iteritems():
+        for group, (x_z, x_t) in convert_x(x).items():
             array = base_vectors_arrays_dict[group]
             out = np.dot(dereference(x_t), dereference(array)).squeeze()
             out = np.dot(dereference(x_z), dereference(out)).squeeze()
@@ -1070,7 +1070,7 @@ class Strategy_temporalRaisedCosine_spatial_cutoff(_Strategy):
                 dict_ = self.convert_x(self.normalize(out.x))
             else:
                 dict_ = self.convert_x(out.x)
-            for group, (x_z, x_t) in dict_.iteritems():
+            for group, (x_z, x_t) in dict_.items():
                 c = self.get_color_by_group(group)
                 self.RaisedCosineBasis_temporal.visualize_x(
                     x_t, ax=ax_t, plot_kwargs={'c': c})

--- a/simrun/modular_reduced_model_inference/strategy.py
+++ b/simrun/modular_reduced_model_inference/strategy.py
@@ -1000,7 +1000,7 @@ class Strategy_temporalRaisedCosine_spatial_cutoff(_Strategy):
     def _convert_x_static(groups, len_z, x):
         len_groups = len(groups)
         out = {}
-        x = x.reshape(len_groups, len(x) / len_groups)
+        x = x.reshape(len_groups, int(len(x) / len_groups))
         for lv, group in enumerate(groups):
             x_z = x[lv, :len_z]
             x_t = x[lv, len_z:]


### PR DESCRIPTION
- add `get_kernel_dict` to `Strategy_spatiotemporalRaisedCosine` (ec51ce136)
- Cast some things to list Forgot the reason why :( But is necessary (594e7fb34)
- use items instead of iteritems, iteritems was useful in Py2, but pretty much deprecated in newer versions of py3, which usees generators by default (c6c4933e5)
- Cast things that need to be int to int (392c665db)
- Recurse keys in subdatabases (937f4804a)