### PR TITLE
Revert "account for labels that are not in the prefix in the hoc_reader"

### DIFF
--- a/single_cell_parser/io/morphology/hoc.py
+++ b/single_cell_parser/io/morphology/hoc.py
@@ -219,7 +219,3 @@ def write_hoc(
             f.write(f"\n{{access {sec_name}}}\n{{nseg = 1}}\n{{pt3dclear()}}")
             for (x, y, z), d in zip(sec.pts, sec.diamList):
                 f.write(f"\n{{pt3dadd({x:.{zero_pad}f}, {y:.{zero_pad}f}, {z:.{zero_pad}f}, {d:.{zero_pad}f})}}")
-
-
-if __name__ == "__main__":
-    _extract_label_and_name_from_hoc("dend_1_0_1")

--- a/single_cell_parser/io/morphology/hoc.py
+++ b/single_cell_parser/io/morphology/hoc.py
@@ -40,8 +40,8 @@ def _extract_label_and_name_from_hoc(
         hoc_prefix = hoc_label
         hoc_suffix = None
 
-    if label.lower() in remap_labels:
-        rename_label = [k for k in remap_labels if k.lower() == label.lower()][0]
+    if hoc_prefix.lower() in remap_labels:
+        rename_label = [k for k in remap_labels if k.lower() == hoc_prefix.lower()][0]
         label = remap_labels[rename_label]
         sec_name = f"{label}"
         if hoc_suffix: sec_name += str(hoc_suffix)

--- a/single_cell_parser/io/morphology/hoc.py
+++ b/single_cell_parser/io/morphology/hoc.py
@@ -40,20 +40,9 @@ def _extract_label_and_name_from_hoc(
         label = hoc_label
         hoc_suffix = None
 
-    matched_key = label.lower() if label.lower() in remap_labels else None
-
-    if matched_key is None:
-        # check if any map key appears anywhere in the full hoc label
-        nonprefix_matches = [k for k in remap_labels if k in hoc_label.lower()]
-        if len(nonprefix_matches) > 1:
-            raise ValueError(
-                f"Ambiguous label '{hoc_label}': multiple map keys match (non-perfix match) as: {nonprefix_matches}"
-            )
-        if nonprefix_matches:
-            matched_key = nonprefix_matches[0]
-
-    if matched_key is not None:
-        label = remap_labels[matched_key]
+    if label.lower() in remap_labels:
+        rename_label = [k for k in remap_labels if k.lower() == label.lower()][0]
+        label = remap_labels[rename_label]
         sec_name = f"{label}"
         if hoc_suffix: sec_name += str(hoc_suffix)
     else:

--- a/single_cell_parser/io/morphology/hoc.py
+++ b/single_cell_parser/io/morphology/hoc.py
@@ -31,13 +31,13 @@ def _extract_label_and_name_from_hoc(
     ):
     remap_labels = remap_labels or {}
     remap_labels = {k.lower(): v for k, v in remap_labels.items()}
-    # Derive the base label: everything before the first '_' or digit
-    hoc_name_match = re.match(r'([A-Za-z\d]+)(_.*)', hoc_label)  # match letters and numbers, NOT underscores
-    if hoc_name_match:
-        label = hoc_name_match.group(1)
-        hoc_suffix = hoc_name_match.group(2)
+    suffix_match = re.findall(r'((?:_\d+)+)', hoc_label)  # match combinations of digits and underscores
+    if len(suffix_match) > 1: raise ValueError("Regex match failed; multiple distinct string segments found that contain underscores and digits.")
+    if len(suffix_match) == 1:
+        hoc_suffix = suffix_match[0]
+        hoc_prefix = hoc_label[:-len(hoc_suffix)]
     else:
-        label = hoc_label
+        hoc_prefix = hoc_label
         hoc_suffix = None
 
     if label.lower() in remap_labels:
@@ -48,7 +48,7 @@ def _extract_label_and_name_from_hoc(
     else:
         sec_name = hoc_label
 
-    return label, sec_name
+    return hoc_prefix, sec_name
 
 
 def read_hoc(
@@ -219,3 +219,7 @@ def write_hoc(
             f.write(f"\n{{access {sec_name}}}\n{{nseg = 1}}\n{{pt3dclear()}}")
             for (x, y, z), d in zip(sec.pts, sec.diamList):
                 f.write(f"\n{{pt3dadd({x:.{zero_pad}f}, {y:.{zero_pad}f}, {z:.{zero_pad}f}, {d:.{zero_pad}f})}}")
+
+
+if __name__ == "__main__":
+    _extract_label_and_name_from_hoc("dend_1_0_1")

--- a/single_cell_parser/io/morphology/hoc.py
+++ b/single_cell_parser/io/morphology/hoc.py
@@ -42,8 +42,8 @@ def _extract_label_and_name_from_hoc(
 
     if hoc_prefix.lower() in remap_labels:
         rename_label = [k for k in remap_labels if k.lower() == hoc_prefix.lower()][0]
-        label = remap_labels[rename_label]
-        sec_name = f"{label}"
+        hoc_prefix = remap_labels[rename_label]
+        sec_name = f"{hoc_prefix}"
         if hoc_suffix: sec_name += str(hoc_suffix)
     else:
         sec_name = hoc_label


### PR DESCRIPTION
I believe there is some confusion (at least there is on my part) on the intended behavior of renaming `hoc` morphology labels.
My intended purpose was to keep the hoc label as it exists in the morphology file, unless explicitly specified otherwise.
The only way in which the user was allowed to specify otherwise, is to provide a mapping between labels that may appear in a `hoc` morphology (in full, to avoid confusion), and some desired rename.
E.g. the label "BasalDendrite" could be renamed to "Dendrite" by extending the hoc label map with `"basaldendrite": "dendrite"`.
It was then up to the user to keep this map unambiguous.

The implementation in https://github.com/mpinb/in_silico_framework/commit/208e888c5e2d8140609846cc56ca8dcd227f53aa is the other way around. Rather than looking in the hoc map to see if some label (in full) needs to be renamed, it looks through the label, and checks if parts of it match a hoc map key. This was not my intended use case for this hoc label map, as it leads to ambiguous definitions for e.g. `"ApicalDendrite"`, as it will match both `apical` and `dend`. While this error is gracefully handled, I'd argue this should not produce an error in the first place. Morphology files should be allowed to specify "ApicalDendrite" as a morphology label, and the user should be able to rename labels like "dend" or "apical" to "Dendrite" and "ApicalDendrite" respectively.