### PR TITLE
Fix unbound meta error

### DIFF
--- a/data_base/IO/LoaderDumper/dask_to_parquet.py
+++ b/data_base/IO/LoaderDumper/dask_to_parquet.py
@@ -127,8 +127,8 @@ class Loader(parent_classes.Loader):
         fnames = os.listdir(savedir)
         fnames = [f for f in fnames if 'pandas_to_parquet' in f]
         n_partitions = int(fnames[0].split('.')[1])
-        if columns: 
-            meta = self.meta[columns]
+        meta = self.meta
+        if columns: meta = meta[columns]
         delayeds = [
             load_helper(savedir, n_partitions, partition, meta=meta, columns=columns)
             for partition in range(n_partitions)


### PR DESCRIPTION
`NameError: free variable 'meta' referenced before assignment in enclosing scope`

d6ea85300a8f9a4218f6fc5822be931e0dcee6eb filtered `meta` on its columns when those were defined (great), but `meta` was now left undefined if no columns were defined (not great)