### PR TITLE
Extend `swc` support to network mapper and tutorial

### DIFF
--- a/getting_started/tutorials/2. network models/2.1 Anatomical embedding.ipynb
+++ b/getting_started/tutorials/2. network models/2.1 Anatomical embedding.ipynb
@@ -58,7 +58,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 179,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -69,7 +69,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 180,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [
     {
@@ -129,7 +129,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 181,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [
     {
@@ -187,13 +187,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 182,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
     {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Warning: no DISPLAY environment variable.\n",
+      "--No graphics will be displayed.\n"
+     ]
+    },
+    {
      "data": {
       "text/plain": [
-       "{'info': {'date': '2026-04-14', 'name': 'meulemeester'},\n",
+       "{'info': {'date': '2026-04-23', 'name': 'meulemeester'},\n",
        " 'network': {'L1_B1': {'cellNr': 8,\n",
        "   'synapses': {'distributionFile': PosixPath('/gpfs/soma_fs/scratch/meulemeester/project_src/in_silico_framework/getting_started/example_data/anatomical_constraints/example_embedding_86_C2_center/example_embedding_86_C2_center.syn'),\n",
        "    'connectionFile': PosixPath('/gpfs/soma_fs/scratch/meulemeester/project_src/in_silico_framework/getting_started/example_data/anatomical_constraints/example_embedding_86_C2_center/example_embedding_86_C2_center.con')}},\n",
@@ -1031,7 +1039,7 @@
        " 'NMODL_mechanisms': {}}"
       ]
      },
-     "execution_count": 182,
+     "execution_count": 4,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1096,7 +1104,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 183,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1114,7 +1122,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 184,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1124,9 +1132,25 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 185,
+   "execution_count": 7,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[INFO] ISF: Current version: heads/morph+0.gc42d144b8.dirty\n",
+      "[INFO] ISF: Current pid: 3075680\n",
+      "[INFO] mechanisms: Loaded mechanisms in NEURON namespace.\n",
+      "[ATTENTION] ISF: The source folder has uncommited changes!\n",
+      "\n",
+      "\n",
+      "\n",
+      "[INFO] ISF: Loaded modules with __version__ attribute are:\n",
+      "IPython: 8.18.1, Interface: heads/morph+0.gc42d144b8.dirty, PIL: 11.3.0, _brotli: 1.1.0, _csv: 1.0, _ctypes: 1.1.0, _curses: b'2.2', _decimal: 1.70, argparse: 1.1, blosc: 1.11.3, bluepyopt: 1.9.126, brotli: 1.1.0, certifi: 2025.08.03, charset_normalizer: 3.4.3, click: 7.1.2, cloudpickle: 3.1.1, colorama: 0.4.6, comm: 0.2.3, csv: 1.0, ctypes: 1.1.0, cycler: 0.12.1, cytoolz: 1.0.1, dash: 2.18.2, dask: 2.30.0, dateutil: 2.9.0.post0, deap: 1.4, debugpy: 1.8.16, decimal: 1.70, decorator: 5.2.1, defusedxml: 0.7.1, distributed: 2.30.0, distutils: 3.9.23, entrypoints: 0.4, exceptiongroup: 1.3.0, executing: 2.2.0, fasteners: 0.17.3, flask: 1.1.4, fsspec: 2025.7.0, future: 1.0.0, greenlet: 3.2.4, idna: 3.10, ipaddress: 1.0, ipykernel: 6.29.5, ipywidgets: 8.1.7, isf_pandas_msgpack: 0.4.0, itsdangerous: 1.1.0, jedi: 0.19.2, jinja2: 2.11.3, joblib: 1.5.1, json: 2.0.9, jupyter_client: 7.3.4, jupyter_core: 5.8.1, kiwisolver: 1.4.7, logging: 0.5.1.2, markupsafe: 2.0.1, matplotlib: 3.3.2, matplotlib_inline: 0.1.7, msgpack: 1.1.1, neuron: 7.8.2+, numcodecs: 0.12.1, numexpr: 2.9.0, numpy: 1.19.2, packaging: 25.0, pandas: 1.1.3, parso: 0.8.4, past: 1.0.0, pexpect: 4.9.0, pickleshare: 0.7.5, platform: 1.0.8, platformdirs: 4.3.8, plotly: 5.24.1, prompt_toolkit: 3.0.51, psutil: 7.0.0, ptyprocess: 0.7.0, pure_eval: 0.2.3, pydevd: 3.2.3, pygments: 2.19.2, pyparsing: 3.2.3, pytz: 2025.2, re: 2.2.1, requests: 2.32.5, scipy: 1.5.2, seaborn: 0.12.2, six: 1.17.0, sklearn: 0.23.2, socketserver: 0.4, socks: 1.7.1, sortedcontainers: 2.4.0, stack_data: 0.6.3, statsmodels: 0.12.1, tables: 3.8.0, tblib: 3.1.0, tlz: 1.0.1, toolz: 1.0.0, tqdm: 4.67.1, traitlets: 5.14.3, urllib3: 2.5.0, wcwidth: 0.2.13, werkzeug: 1.0.1, yaml: 6.0.2, zarr: 2.15.0, zlib: 1.0, zmq: 27.0.2, zstandard: 0.23.0\n"
+     ]
+    }
+   ],
    "source": [
     "%matplotlib inline\n",
     "import Interface as I\n",
@@ -1149,7 +1173,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 186,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
@@ -1165,7 +1189,7 @@
        " 'example_embedding_86_C2_center']"
       ]
      },
-     "execution_count": 186,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1177,19 +1201,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 187,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "path_to_hoc = I.os.path.join(\n",
+    "path_to_morph = I.os.path.join(\n",
     "    anatomy_dir,\n",
-    "    '86_C2_center.hoc')\n",
-    "path_to_scaled_hoc = I.os.path.join(\n",
-    "    anatomy_dir,\n",
-    "    '86_C2_center_scaled_diameters.hoc')\n",
-    "\n",
-    "assert I.os.path.exists(path_to_hoc)\n",
-    "assert I.os.path.exists(path_to_scaled_hoc)"
+    "    '86_C2_center.swc')\n",
+    "assert I.os.path.exists(path_to_morph)"
    ]
   },
   {
@@ -1201,7 +1220,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 188,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -1210,7 +1229,7 @@
        "'/gpfs/soma_fs/home/meulemeester/isf_tutorial_output/network_modeling/db/anatomical_constraints/86_C2_center_scaled_diameters.hoc'"
       ]
      },
-     "execution_count": 188,
+     "execution_count": 12,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1218,8 +1237,7 @@
    "source": [
     "if not 'anatomical_constraints' in db.keys():\n",
     "    db.create_managed_folder('anatomical_constraints')\n",
-    "I.shutil.copy(path_to_hoc, db['anatomical_constraints'])\n",
-    "I.shutil.copy(path_to_scaled_hoc, db['anatomical_constraints'])"
+    "I.shutil.copy(path_to_morph, db['anatomical_constraints'])"
    ]
   },
   {
@@ -1253,7 +1271,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 189,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [
     {
@@ -1266,12 +1284,11 @@
       "[INFO] udvary2022: No InhPSTDensityName passed. Falling back to user-configured one.\n",
       "[INFO] udvary2022: No boutonDensityFolderName passed. Falling back to user-configured one.\n",
       "[INFO] udvary2022: Loading cell morphology\n",
-      "[INFO] reader: Reading hoc file: /gpfs/soma_fs/home/meulemeester/isf_tutorial_output/network_modeling/db/anatomical_constraints/86_C2_center.hoc\n",
       "[INFO] udvary2022: Loading spreadsheets and bouton/PST densities...\n",
       "[INFO] udvary2022:     Loading numberOfCells spreadsheet /gpfs/soma_fs/scratch/meulemeester/project_src/in_silico_framework/barrel_cortex/nrCells.csv\n",
       "[INFO] udvary2022:     Loading bouton densities from folder /gpfs/soma_fs/scratch/meulemeester/project_src/in_silico_framework/barrel_cortex/singleaxon_boutons_ascii (may take a while)\n",
-      "[INFO] udvary2022:     Loaded bouton densities in 1062.83 s\n",
-      "[INFO] udvary2022: Creating network embedding for  /gpfs/soma_fs/home/meulemeester/isf_tutorial_output/network_modeling/db/anatomical_constraints/86_C2_center.hoc\n",
+      "[INFO] udvary2022:     Loaded bouton densities in 766.89 s\n",
+      "[INFO] udvary2022: Creating network embedding for  /gpfs/soma_fs/home/meulemeester/isf_tutorial_output/network_modeling/db/anatomical_constraints/86_C2_center.swc\n",
       "[INFO] network_embedding: ---------------------------\n",
       "[INFO] network_embedding: Created 536162 presynaptic cells in total\n",
       "[INFO] network_embedding: ---------------------------\n",
@@ -1294,19 +1311,19 @@
       "[INFO] network_embedding: ---------------------------\n",
       "[INFO] network_embedding: Writing output files...\n",
       "\n",
-      "Directory Name is  /gpfs/soma_fs/home/meulemeester/isf_tutorial_output/network_modeling/db/anatomical_constraints/86_C2_center_synapses_20260414-2153_1819524/\n",
-      "CSV file name is  /gpfs/soma_fs/home/meulemeester/isf_tutorial_output/network_modeling/db/anatomical_constraints/86_C2_center_synapses_20260414-2153_1819524/86_C2_center_summary_20260414-2153_1819524\n",
+      "Directory Name is  /gpfs/soma_fs/home/meulemeester/isf_tutorial_output/network_modeling/db/anatomical_constraints/86_C2_center_synapses_20260423-1501_3075680/\n",
+      "CSV file name is  /gpfs/soma_fs/home/meulemeester/isf_tutorial_output/network_modeling/db/anatomical_constraints/86_C2_center_synapses_20260423-1501_3075680/86_C2_center_summary_20260423-1501_3075680\n",
       "\n",
       "---------------------------\n",
       "[INFO] network_embedding: Done generating network embedding!\n",
       "[INFO] network_embedding: ---------------------------\n",
-      "[INFO] udvary2022: Runtime: 20.2 minutes\n"
+      "[INFO] udvary2022: Runtime: 15.2 minutes\n"
      ]
     }
    ],
    "source": [
     "celltype = 'L5tt'  # Layer 5 thick-tufted\n",
-    "morphology_fn = db['anatomical_constraints'].join('86_C2_center.hoc')\n",
+    "morphology_fn = db['anatomical_constraints'].join('86_C2_center.swc')\n",
     "\n",
     "I.logger.setLevel(\"INFO\") # verbose output\n",
     "I.map_singlecell_inputs(\n",
@@ -1319,14 +1336,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Saved embedding results to:  /gpfs/soma_fs/home/meulemeester/isf_tutorial_output/network_modeling/db/anatomical_constraints/86_C2_center_synapses_20260319-1801_4193665\n"
+      "Saved embedding results to:  /gpfs/soma_fs/home/meulemeester/isf_tutorial_output/network_modeling/db/anatomical_constraints/86_C2_center_synapses_20260423-1501_3075680\n"
      ]
     }
    ],
@@ -1509,7 +1526,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [
     {
@@ -1517,15 +1534,18 @@
       "text/plain": [
        "['Loader.json',\n",
        " 'example_embedding_86_C2_center.con',\n",
+       " '86_C2_center_synapses_20260423-1501_3075680',\n",
        " 'NumberOfConnectedCells.csv',\n",
        " '86_C2_center.hoc',\n",
+       " '86_C2_center_synapses_20260414-2153_1819524',\n",
        " 'example_embedding_86_C2_center.syn',\n",
        " 'example_embedding',\n",
+       " '86_C2_center.swc',\n",
        " 'metadata.json',\n",
        " '86_C2_center_scaled_diameters.hoc']"
       ]
      },
-     "execution_count": 11,
+     "execution_count": 15,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1543,7 +1563,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [
     {
@@ -1586,7 +1606,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [
     {
@@ -1633,7 +1653,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 18,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1651,7 +1671,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 19,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1669,7 +1689,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 20,
    "metadata": {},
    "outputs": [
     {
@@ -1685,8 +1705,8 @@
    ],
    "source": [
     "%matplotlib inline\n",
-    "from visualize.dendrogram import DendrogramStatistics\n",
     "I.plt.style.use(\"fivethirtyeight\")\n",
+    "from visualize.dendrogram import DendrogramStatistics\n",
     "\n",
     "dg = DendrogramStatistics(cell)\n",
     "dg.plot(figsize=(8, 15));"
@@ -1701,7 +1721,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 101,
+   "execution_count": 21,
    "metadata": {},
    "outputs": [
     {

--- a/singlecell_input_mapper/udvary2022/__init__.py
+++ b/singlecell_input_mapper/udvary2022/__init__.py
@@ -188,8 +188,8 @@ def map_singlecell_inputs(
 
     start_t_sec_total = time.time()
 
-    logger.info("Loading cell morphology")
-    parser = CellParser(cellName)
+    logger.info("Loading cell morphology: {}".format(cellName))
+    parser = CellParser(morph_fn=cellName)
     parser.spatialgraph_to_cell()
     singleCell = parser.get_cell()  # This is a sim.Cell, not scp.cell
     logger.debug("Cell morphology loaded")

--- a/singlecell_input_mapper/udvary2022/cell.py
+++ b/singlecell_input_mapper/udvary2022/cell.py
@@ -20,7 +20,7 @@ For functional network realizations (i.e. known presynaptic origin of each synap
 '''
 from __future__ import absolute_import
 import numpy as np
-from . import reader
+from single_cell_parser.io.morphology import read_morphology
 __author__ = 'Robert Egger'
 __date__ = '2012-04-28'
 
@@ -383,12 +383,12 @@ class CellParser(object):
     '''
     cell = None
 
-    def __init__(self, hocFilename=''):
+    def __init__(self, morph_fn=''):
         '''
         Args:
             hocFilename (str): File name of the hoc file. Default: ''.
         '''
-        self.hoc_fname = hocFilename
+        self.morph_fn = morph_fn
 
     def spatialgraph_to_cell(self):
         '''Set up a cell object from an AMIRA hoc file.
@@ -401,13 +401,13 @@ class CellParser(object):
             To ensure reproducability, scaleFunc should be specified in the cell parameters, as 
             described in :mod:`~single_cell_parser.cell_modify_funs`
         '''
-        edgeList = reader.read_hoc_file(self.hoc_fname)
-        self.hoc_fname = self.hoc_fname.split('/')[-1]
+        edgeList = read_morphology(self.morph_fn)
+        self.morph_fn = self.morph_fn.split('/')[-1]
         #part1 = self.hoc_fname.split('_')[0]
         #part2 = self.hoc_fname.split('_')[1]
         #part3 = self.hoc_fname.split('.')[-2]
         self.cell = Cell()
-        self.cell.id = self.hoc_fname  # '_'.join([part1, part2, part3])
+        self.cell.id = self.morph_fn  # '_'.join([part1, part2, part3])
 
         #        # first loop: create all Sections
         for edge in edgeList:


### PR DESCRIPTION
Udvary was still limited to `hoc` morphologies only. I simply swapped the `hoc` morphology reader with the generic `read_morphology`. This was all that was needed to make the entire workflow `swc` compatible

Updated tutorial 2.1 to not say `hoc` morphology, but just `morphology`. Tested if it works with `swc`. It does.