### PR TITLE
Docs update

### DIFF
--- a/docs/file_formats.rst
+++ b/docs/file_formats.rst
@@ -980,7 +980,6 @@ Example:
   BREAKPOINT {
     : Solve the DERIVATIVE block named "states"
     : Use `cnexp` (Crank-Nicolson, exponential)
-    : For more info, see https://www.neuronsimulator.org/en/latest/nmodl/transpiler/notebooks/nmodl-sympy-solver-cnexp.html#Implementation
     SOLVE states METHOD cnexp
     : Calculate the conductance of the Im current = conductance density * gating variable
     gIm = gImbar*m

--- a/single_cell_parser/cell_parser.py
+++ b/single_cell_parser/cell_parser.py
@@ -383,7 +383,7 @@ class CellParser(object):
              - :math:`y = \text{slope} \cdot x + \text{offset}`
            * - linear_capped
              - ``prox_value``, ``dist_value``, ``dist_value_distance``
-             - :math:`y = \min(\text{prox_value} + \frac{\text{dist_value} - \text{prox_value}}{\text{dist_value_distance}} x, \text{dist_value})`
+             - :math:`y = \max(\text{prox_value} + \frac{\text{dist_value} - \text{prox_value}}{\text{dist_value_distance}} x, \text{dist_value})`
            * - exponential
              - ``offset``, ``linScale``, ``_lambda``, ``xOffset``
              - :math:`y = \text{offset} + \text{linScale} \cdot e^{-\frac{x - \text{xOffset}}{\lambda}}`
@@ -599,11 +599,8 @@ class CellParser(object):
                             or param == 'linScale' or param == '_lambda' or param == 'xOffset':
                                 continue
                             dist = h.distance(seg.x, sec=sec)
-                            if relDistance:
-                                dist = dist / maxDist
-                            rangeVarVal = mech[param] * (
-                                offset + linScale * np.exp(_lambda *
-                                                           (dist - xOffset)))
+                            if relDistance: dist = dist / maxDist
+                            rangeVarVal = mech[param] * (offset + linScale * np.exp(_lambda * (dist - xOffset)))
                             if rangeVarVal < max_g:
                                 s = param + '=' + str(rangeVarVal)
                                 paramStrings.append(s)


### PR DESCRIPTION
- `max` instead of `min` for linear capped spatial profile in `single_cell_parser.cell_parser.CellParser.insert_range_mechanisms`
- remove `sympy` link in NMODL format docs